### PR TITLE
Feat/eng 445 create providers pool

### DIFF
--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.4.24;
+
+import "./SortedDoublyLL.sol";
+import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+
+contract ProviderPool is Ownable {
+  using SortedDoublyLL for SortedDoublyLL.Data;
+  SortedDoublyLL.Data public providerPool;
+
+  function setMaxNumberOfProviders(uint _maxNumber) external onlyOwner {
+    providerPool.setMaxSize(_maxNumber);
+  }
+
+  function addProvider(address _providerAddress, uint _bondedAmount) internal {
+    providerPool.insert(_providerAddress, _bondedAmount, 0, 0);
+  }
+}

--- a/contracts/SortedDoublyLL.sol
+++ b/contracts/SortedDoublyLL.sol
@@ -1,0 +1,341 @@
+pragma solidity ^0.4.17;
+
+import "zeppelin-solidity/contracts/math/SafeMath.sol";
+
+
+/*
+ * @title A sorted doubly linked list with nodes sorted in descending order. Optionally accepts insert position hints
+ *
+ * Given a new node with a `key`, a hint is of the form `(prevId, nextId)` s.t. `prevId` and `nextId` are adjacent in the list.
+ * `prevId` is a node with a key >= `key` and `nextId` is a node with a key <= `key`. If the sender provides a hint that is a valid insert position
+ * the insert operation is a constant time storage write. However, the provided hint in a given transaction might be a valid insert position, but if other transactions are included first, when
+ * the given transaction is executed the provided hint may no longer be a valid insert position. For example, one of the nodes referenced might be removed or their keys may
+ * be updated such that the the pair of nodes in the hint no longer represent a valid insert position. If one of the nodes in the hint becomes invalid, we still try to use the other
+ * valid node as a starting point for finding the appropriate insert position. If both nodes in the hint become invalid, we use the head of the list as a starting point
+ * to find the appropriate insert position.
+ */
+library SortedDoublyLL {
+    using SafeMath for uint256;
+
+    // Information for a node in the list
+    struct Node {
+        uint256 key;                     // Node's key used for sorting
+        address nextId;                  // Id of next node (smaller key) in the list
+        address prevId;                  // Id of previous node (larger key) in the list
+    }
+
+    // Information for the list
+    struct Data {
+        address head;                        // Head of the list. Also the node in the list with the largest key
+        address tail;                        // Tail of the list. Also the node in the list with the smallest key
+        uint256 maxSize;                     // Maximum size of the list
+        uint256 size;                        // Current size of the list
+        mapping (address => Node) nodes;     // Track the corresponding ids for each node in the list
+    }
+
+    /*
+     * @dev Set the maximum size of the list
+     * @param _size Maximum size
+     */
+    function setMaxSize(Data storage self, uint256 _size) public {
+        // New max size must be greater than old max size
+        require(_size > self.maxSize);
+
+        self.maxSize = _size;
+    }
+
+    /*
+     * @dev Add a node to the list
+     * @param _id Node's id
+     * @param _key Node's key
+     * @param _prevId Id of previous node for the insert position
+     * @param _nextId Id of next node for the insert position
+     */
+    function insert(Data storage self, address _id, uint256 _key, address _prevId, address _nextId) public {
+        // List must not be full
+        require(!isFull(self));
+        // List must not already contain node
+        require(!contains(self, _id));
+        // Node id must not be null
+        require(_id != address(0));
+        // Key must be non-zero
+        require(_key > 0);
+
+        address prevId = _prevId;
+        address nextId = _nextId;
+
+        if (!validInsertPosition(self, _key, prevId, nextId)) {
+            // Sender's hint was not a valid insert position
+            // Use sender's hint to find a valid insert position
+            (prevId, nextId) = findInsertPosition(self, _key, prevId, nextId);
+        }
+
+        self.nodes[_id].key = _key;
+
+        if (prevId == address(0) && nextId == address(0)) {
+            // Insert as head and tail
+            self.head = _id;
+            self.tail = _id;
+        } else if (prevId == address(0)) {
+            // Insert before `prevId` as the head
+            self.nodes[_id].nextId = self.head;
+            self.nodes[self.head].prevId = _id;
+            self.head = _id;
+        } else if (nextId == address(0)) {
+            // Insert after `nextId` as the tail
+            self.nodes[_id].prevId = self.tail;
+            self.nodes[self.tail].nextId = _id;
+            self.tail = _id;
+        } else {
+            // Insert at insert position between `prevId` and `nextId`
+            self.nodes[_id].nextId = nextId;
+            self.nodes[_id].prevId = prevId;
+            self.nodes[prevId].nextId = _id;
+            self.nodes[nextId].prevId = _id;
+        }
+
+        self.size = self.size.add(1);
+    }
+
+    /*
+     * @dev Remove a node from the list
+     * @param _id Node's id
+     */
+    function remove(Data storage self, address _id) public {
+        // List must contain the node
+        require(contains(self, _id));
+
+        if (self.size > 1) {
+            // List contains more than a single node
+            if (_id == self.head) {
+                // The removed node is the head
+                // Set head to next node
+                self.head = self.nodes[_id].nextId;
+                // Set prev pointer of new head to null
+                self.nodes[self.head].prevId = address(0);
+            } else if (_id == self.tail) {
+                // The removed node is the tail
+                // Set tail to previous node
+                self.tail = self.nodes[_id].prevId;
+                // Set next pointer of new tail to null
+                self.nodes[self.tail].nextId = address(0);
+            } else {
+                // The removed node is neither the head nor the tail
+                // Set next pointer of previous node to the next node
+                self.nodes[self.nodes[_id].prevId].nextId = self.nodes[_id].nextId;
+                // Set prev pointer of next node to the previous node
+                self.nodes[self.nodes[_id].nextId].prevId = self.nodes[_id].prevId;
+            }
+        } else {
+            // List contains a single node
+            // Set the head and tail to null
+            self.head = address(0);
+            self.tail = address(0);
+        }
+
+        delete self.nodes[_id];
+        self.size = self.size.sub(1);
+    }
+
+    /*
+     * @dev Update the key of a node in the list
+     * @param _id Node's id
+     * @param _newKey Node's new key
+     * @param _prevId Id of previous node for the new insert position
+     * @param _nextId Id of next node for the new insert position
+     */
+    function updateKey(Data storage self, address _id, uint256 _newKey, address _prevId, address _nextId) public {
+        // List must contain the node
+        require(contains(self, _id));
+
+        // Remove node from the list
+        remove(self, _id);
+
+        if (_newKey > 0) {
+            // Insert node if it has a non-zero key
+            insert(self, _id, _newKey, _prevId, _nextId);
+        }
+    }
+
+    /*
+     * @dev Checks if the list contains a node
+     * @param _transcoder Address of transcoder
+     */
+    function contains(Data storage self, address _id) public view returns (bool) {
+        // List only contains non-zero keys, so if key is non-zero the node exists
+        return self.nodes[_id].key > 0;
+    }
+
+    /*
+     * @dev Checks if the list is full
+     */
+    function isFull(Data storage self) public view returns (bool) {
+        return self.size == self.maxSize;
+    }
+
+    /*
+     * @dev Checks if the list is empty
+     */
+    function isEmpty(Data storage self) public view returns (bool) {
+        return self.size == 0;
+    }
+
+    /*
+     * @dev Returns the current size of the list
+     */
+    function getSize(Data storage self) public view returns (uint256) {
+        return self.size;
+    }
+
+    /*
+     * @dev Returns the maximum size of the list
+     */
+    function getMaxSize(Data storage self) public view returns (uint256) {
+        return self.maxSize;
+    }
+
+    /*
+     * @dev Returns the key of a node in the list
+     * @param _id Node's id
+     */
+    function getKey(Data storage self, address _id) public view returns (uint256) {
+        return self.nodes[_id].key;
+    }
+
+    /*
+     * @dev Returns the first node in the list (node with the largest key)
+     */
+    function getFirst(Data storage self) public view returns (address) {
+        return self.head;
+    }
+
+    /*
+     * @dev Returns the last node in the list (node with the smallest key)
+     */
+    function getLast(Data storage self) public view returns (address) {
+        return self.tail;
+    }
+
+    /*
+     * @dev Returns the next node (with a smaller key) in the list for a given node
+     * @param _id Node's id
+     */
+    function getNext(Data storage self, address _id) public view returns (address) {
+        return self.nodes[_id].nextId;
+    }
+
+    /*
+     * @dev Returns the previous node (with a larger key) in the list for a given node
+     * @param _id Node's id
+     */
+    function getPrev(Data storage self, address _id) public view returns (address) {
+        return self.nodes[_id].prevId;
+    }
+
+    /*
+     * @dev Check if a pair of nodes is a valid insertion point for a new node with the given key
+     * @param _key Node's key
+     * @param _prevId Id of previous node for the insert position
+     * @param _nextId Id of next node for the insert position
+     */
+    function validInsertPosition(Data storage self, uint256 _key, address _prevId, address _nextId) public view returns (bool) {
+        if (_prevId == address(0) && _nextId == address(0)) {
+            // `(null, null)` is a valid insert position if the list is empty
+            return isEmpty(self);
+        } else if (_prevId == address(0)) {
+            // `(null, _nextId)` is a valid insert position if `_nextId` is the head of the list
+            return self.head == _nextId && _key >= self.nodes[_nextId].key;
+        } else if (_nextId == address(0)) {
+            // `(_prevId, null)` is a valid insert position if `_prevId` is the tail of the list
+            return self.tail == _prevId && _key <= self.nodes[_prevId].key;
+        } else {
+            // `(_prevId, _nextId)` is a valid insert position if they are adjacent nodes and `_key` falls between the two nodes' keys
+            return self.nodes[_prevId].nextId == _nextId && self.nodes[_prevId].key >= _key && _key >= self.nodes[_nextId].key;
+        }
+    }
+
+    /*
+     * @dev Descend the list (larger keys to smaller keys) to find a valid insert position
+     * @param _key Node's key
+     * @param _startId Id of node to start ascending the list from
+     */
+    function descendList(Data storage self, uint256 _key, address _startId) private view returns (address, address) {
+        // If `_startId` is the head, check if the insert position is before the head
+        if (self.head == _startId && _key >= self.nodes[_startId].key) {
+            return (address(0), _startId);
+        }
+
+        address prevId = _startId;
+        address nextId = self.nodes[prevId].nextId;
+
+        // Descend the list until we reach the end or until we find a valid insert position
+        while (prevId != address(0) && !validInsertPosition(self, _key, prevId, nextId)) {
+            prevId = self.nodes[prevId].nextId;
+            nextId = self.nodes[prevId].nextId;
+        }
+
+        return (prevId, nextId);
+    }
+
+    /*
+     * @dev Ascend the list (smaller keys to larger keys) to find a valid insert position
+     * @param _key Node's key
+     * @param _startId Id of node to start descending the list from
+     */
+    function ascendList(Data storage self, uint256 _key, address _startId) private view returns (address, address) {
+        // If `_startId` is the tail, check if the insert position is after the tail
+        if (self.tail == _startId && _key <= self.nodes[_startId].key) {
+            return (_startId, address(0));
+        }
+
+        address nextId = _startId;
+        address prevId = self.nodes[nextId].prevId;
+
+        // Ascend the list until we reach the end or until we find a valid insertion point
+        while (nextId != address(0) && !validInsertPosition(self, _key, prevId, nextId)) {
+            nextId = self.nodes[nextId].prevId;
+            prevId = self.nodes[nextId].prevId;
+        }
+
+        return (prevId, nextId);
+    }
+
+    /*
+     * @dev Find the insert position for a new node with the given key
+     * @param _key Node's key
+     * @param _prevId Id of previous node for the insert position
+     * @param _nextId Id of next node for the insert position
+     */
+    function findInsertPosition(Data storage self, uint256 _key, address _prevId, address _nextId) private view returns (address, address) {
+        address prevId = _prevId;
+        address nextId = _nextId;
+
+        if (prevId != address(0)) {
+            if (!contains(self, prevId) || _key > self.nodes[prevId].key) {
+                // `prevId` does not exist anymore or now has a smaller key than the given key
+                prevId = address(0);
+            }
+        }
+
+        if (nextId != address(0)) {
+            if (!contains(self, nextId) || _key < self.nodes[nextId].key) {
+                // `nextId` does not exist anymore or now has a larger key than the given key
+                nextId = address(0);
+            }
+        }
+
+        if (prevId == address(0) && nextId == address(0)) {
+            // No hint - descend list starting from head
+            return descendList(self, _key, self.head);
+        } else if (prevId == address(0)) {
+            // No `prevId` for hint - ascend list starting from `nextId`
+            return ascendList(self, _key, nextId);
+        } else if (nextId == address(0)) {
+            // No `nextId` for hint - descend list starting from `prevId`
+            return descendList(self, _key, prevId);
+        } else {
+            // Descend list starting from `prevId`
+            return descendList(self, _key, prevId);
+        }
+    }
+}

--- a/contracts/TestProviderPool.sol
+++ b/contracts/TestProviderPool.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.24;
 import "../contracts/ProviderPool.sol";
 
 contract TestProviderPool is ProviderPool {
-  // @dev convenience method to access the mapping inside SortedDoublyLL.Data from web3js
+  // @dev convenience method to access from web3js the 'nodes' mapping that lives inside SortedDoublyLL.Data
   function get(address _provider) returns (uint, address, address) {
     return (providerPool.nodes[_provider].key, providerPool.nodes[_provider].nextId, providerPool.nodes[_provider].prevId);
   }

--- a/contracts/TestProviderPool.sol
+++ b/contracts/TestProviderPool.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.4.24;
+
+import "../contracts/ProviderPool.sol";
+
+contract TestProviderPool is ProviderPool {
+  // @dev convenience method to access the mapping inside SortedDoublyLL.Data from web3js
+  function get(address _provider) returns (uint, address, address) {
+    return (providerPool.nodes[_provider].key, providerPool.nodes[_provider].nextId, providerPool.nodes[_provider].prevId);
+  }
+
+  // @dev convenience method to be able to call addProvider from web3js (it has internal visibility)
+  function publicAddProvider(address _providerAddress, uint _bondedAmount) public {
+    addProvider(_providerAddress, _bondedAmount);
+  }
+}
+

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,9 +1,14 @@
 const TST = artifacts.require('./TransmuteToken.sol');
 const ProviderRound = artifacts.require('./ProviderRound.sol');
 const RoundManager = artifacts.require('./RoundManager.sol');
+const SortedDoublyLL = artifacts.require('./SortedDoublyLL.sol');
+const TestProviderPool = artifacts.require('./TestProviderPool.sol');
 
 module.exports = deployer => {
   deployer.deploy(TST);
   deployer.deploy(ProviderRound);
   deployer.deploy(RoundManager);
+  deployer.deploy(SortedDoublyLL);
+  deployer.link(SortedDoublyLL, TestProviderPool);
+  deployer.deploy(TestProviderPool);
 };

--- a/test/TestProviderPool.spec.js
+++ b/test/TestProviderPool.spec.js
@@ -1,0 +1,83 @@
+// Here we use the TestProviderPool contract instead of the ProviderPool
+// This is to be able to test the addProvider function which has internal visibility 
+// through the publicAddProvider function from TestProviderPool which has public visibility
+const ProviderPool = artifacts.require('./TestProviderPool.sol');
+const { blockMiner, assertFail } = require('./utils.js');
+
+contract('ProviderPool', accounts => {
+
+  let pp;
+
+  describe('setMaxNumberOfProviders', () => {
+
+    before(async () => {
+      pp = await ProviderPool.deployed();
+    });
+
+    it('should set the max number of providers allowed in the pool', async () => {
+      let providerPool = await pp.providerPool.call();
+      assert.equal(0, providerPool[2]); // max size
+      await pp.setMaxNumberOfProviders(7, {from: accounts[0]});
+      providerPool = await pp.providerPool.call();
+      assert.equal(7, providerPool[2]);
+    });
+
+    it("should fail if it is not called from the owner's address", async () => {
+      await assertFail( pp.setMaxNumberOfProviders(10, {from: accounts[1]}) );
+    });
+
+    it("should fail if new size is less than current size", async () => {
+      await assertFail( pp.setMaxNumberOfProviders(6, {from: accounts[0]}) );
+    });
+  });
+
+  describe('addProvider', () => {
+
+    it('should add a provider to the pool', async () => {
+      let providerPool = await pp.providerPool.call();
+      assert.equal(0, providerPool[0]); // address head
+      assert.equal(0, providerPool[1]); // address tail
+      assert.equal(0, providerPool[3]); // size
+      await pp.publicAddProvider(accounts[1], 10);
+      providerPool = await pp.providerPool.call();
+      assert.equal(accounts[1], providerPool[0]); // address head
+      assert.equal(accounts[1], providerPool[1]); // address tail
+      assert.equal(1, providerPool[3]); // size
+    });
+
+    it('should keep the list sorted by descending order of bondedAmount', async () => {
+      const assertProvidersAreSortedByBondedAmount = async () => {
+        let bondedAmountOfPreviousAddress = Number.POSITIVE_INFINITY; 
+        let previousAddress = 0;
+        let providerPool = await pp.providerPool.call();
+        let currentAddress = providerPool[0];
+        let node = await pp.get.call(currentAddress);
+        let end = providerPool[1];
+        do {
+          assert(node[0] <= bondedAmountOfPreviousAddress); //
+          assert.equal(node[2], previousAddress);
+          previousAddress = currentAddress;
+          currentAddress = node[1];
+          node = await pp.get.call(currentAddress);
+        }
+        while(currentAddress != end)
+      }
+
+      await pp.publicAddProvider(accounts[2], 6);
+      await assertProvidersAreSortedByBondedAmount();
+      await pp.publicAddProvider(accounts[3], 13);
+      await assertProvidersAreSortedByBondedAmount();
+      await pp.publicAddProvider(accounts[4], 2);
+      await assertProvidersAreSortedByBondedAmount();
+      await pp.publicAddProvider(accounts[5], 8);
+      await assertProvidersAreSortedByBondedAmount();
+      await pp.publicAddProvider(accounts[6], 15);
+      await assertProvidersAreSortedByBondedAmount();
+    });
+
+    it('should fail if pool size exceeds maxSize', async () => {
+
+    })
+  });
+});
+

--- a/test/TestProviderPool.spec.js
+++ b/test/TestProviderPool.spec.js
@@ -71,13 +71,20 @@ contract('ProviderPool', accounts => {
       await assertProvidersAreSortedByBondedAmount();
       await pp.publicAddProvider(accounts[5], 8);
       await assertProvidersAreSortedByBondedAmount();
-      await pp.publicAddProvider(accounts[6], 15);
+      await pp.publicAddProvider(accounts[6], 8);
       await assertProvidersAreSortedByBondedAmount();
     });
 
-    it('should fail if pool size exceeds maxSize', async () => {
+    it('should fail if the same address is added twice', async () => {
+      await assertFail( pp.publicAddProvider(accounts[6], 15) );
+    });
 
-    })
+    it('should fail if pool size exceeds maxSize', async () => {
+      // Max size is 7, the 7th account should make it
+      await pp.publicAddProvider(accounts[7], 15);
+      // And the 8th should fail
+      await assertFail( pp.publicAddProvider(accounts[8], 15) );
+    });
   });
 });
 


### PR DESCRIPTION
https://transmute.atlassian.net/browse/ENG-445

This PR creates the contract ProviderPool, a data structure that allows to store providers sorted by their bondedAmount.

It uses the [SortedDoublyLL library from LivePeer's repo](https://github.com/livepeer/protocol/blob/master/contracts/libraries/SortedDoublyLL.sol). The ProviderPool contracts acts as an interface that the main contract will inherit from in the future.

In order to test it's internal function `addProvider`, a test contract has been created. It creates the same contract but with a `publicAddProvider` method that can be called from web3js