### PR TITLE
Feat/eng 442 link provider function to provider pool

### DIFF
--- a/.soliumignore
+++ b/.soliumignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,0 +1,16 @@
+{
+  "extends": "solium:recommended",
+  "plugins": [
+    "security"
+  ],
+  "rules": {
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "indentation": [
+      "error",
+      2
+    ]
+  }
+}

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -22,12 +22,11 @@ contract ProviderPool is Ownable {
     providerPool.setMaxSize(_maxNumber);
   }
 
-  // TODO: Replace _providerAddress
-  function addProvider(address _providerAddress, uint _bondedAmount) internal {
-    providerPool.insert(_providerAddress, _bondedAmount, 0, 0);
+  function addProvider(address _provider, uint _bondedAmount) internal {
+    providerPool.insert(_provider, _bondedAmount, 0, 0);
   }
 
-  function updateProvider(address _providerAddress, uint _newBondedAmount) internal {
-    providerPool.updateKey(_providerAddress, _newBondedAmount, 0, 0);
+  function updateProvider(address _provider, uint _newBondedAmount) internal {
+    providerPool.updateKey(_provider, _newBondedAmount, 0, 0);
   }
 }

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -7,6 +7,12 @@ contract ProviderPool is Ownable {
   using SortedDoublyLL for SortedDoublyLL.Data;
   SortedDoublyLL.Data public providerPool;
 
+  // @dev convenience method to access the 'nodes' mapping that lives inside providerPool
+  function getProvider(address _provider) public view returns (uint, address, address) {
+    SortedDoublyLL.Node memory node = providerPool.nodes[_provider];
+    return (node.key, node.nextId, node.prevId);
+  }
+
   function setMaxNumberOfProviders(uint _maxNumber) external onlyOwner {
     providerPool.setMaxSize(_maxNumber);
   }

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -8,7 +8,7 @@ contract ProviderPool is Ownable {
   SortedDoublyLL.Data public providerPool;
 
   // @dev convenience method to access the 'nodes' mapping that lives inside providerPool
-  function getProvider(address _provider) public view returns (uint, address, address) {
+  function getProvider(address _provider) external view returns (uint, address, address) {
     SortedDoublyLL.Node memory node = providerPool.nodes[_provider];
     return (node.key, node.nextId, node.prevId);
   }

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -22,7 +22,12 @@ contract ProviderPool is Ownable {
     providerPool.setMaxSize(_maxNumber);
   }
 
+  // TODO: Replace _providerAddress
   function addProvider(address _providerAddress, uint _bondedAmount) internal {
     providerPool.insert(_providerAddress, _bondedAmount, 0, 0);
+  }
+
+  function updateProvider(address _providerAddress, uint _newBondedAmount) internal {
+    providerPool.updateKey(_providerAddress, _newBondedAmount, 0, 0);
   }
 }

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -13,6 +13,11 @@ contract ProviderPool is Ownable {
     return (node.key, node.nextId, node.prevId);
   }
 
+  function containsProvider(address _provider) external view returns (bool) {
+    return providerPool.contains(_provider);
+  }
+
+  // TODO: Add default value in the main constructor
   function setMaxNumberOfProviders(uint _maxNumber) external onlyOwner {
     providerPool.setMaxSize(_maxNumber);
   }

--- a/contracts/ProviderRound.sol
+++ b/contracts/ProviderRound.sol
@@ -4,7 +4,7 @@ import "./TransmuteToken.sol";
 import "./RoundManager.sol";
 import "./ProviderPool.sol";
 
-// TODO Change name
+// TODO Change name to TransmuteDPOS
 contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
 
   event ProviderAdded (
@@ -35,6 +35,7 @@ contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
   uint public numberOfDelegators;
   mapping(address => Delegator) public delegators;
 
+  // TODO: Change name to Unregistered
   enum ProviderStatus { Null, Registered }
 
   struct Provider {
@@ -61,8 +62,10 @@ contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
     if (provider.status == ProviderStatus.Null) {
       numberOfProviders = numberOfProviders.add(1);
       addProvider(msg.sender, provider.totalAmountBonded);
+      // TODO: Fix warning
       ProviderAdded(msg.sender, _pricePerStorageMineral, _pricePerComputeMineral, _blockRewardCut, _feeShare);
     } else {
+      updateProvider(msg.sender, provider.totalAmountBonded);
       ProviderUpdated(msg.sender, _pricePerStorageMineral, _pricePerComputeMineral, _blockRewardCut, _feeShare);
     }
     provider.status = ProviderStatus.Registered;

--- a/contracts/ProviderRound.sol
+++ b/contracts/ProviderRound.sol
@@ -4,7 +4,7 @@ import "./TransmuteToken.sol";
 import "./RoundManager.sol";
 import "./ProviderPool.sol";
 
-// TODO Change name to TransmuteDPOS
+// TODO: Change name to TransmuteDPOS
 contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
 
   event ProviderAdded (
@@ -35,8 +35,7 @@ contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
   uint public numberOfDelegators;
   mapping(address => Delegator) public delegators;
 
-  // TODO: Change name to Unregistered
-  enum ProviderStatus { Null, Registered }
+  enum ProviderStatus { Unregistered, Registered }
 
   struct Provider {
     ProviderStatus status;
@@ -59,7 +58,7 @@ contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
     Delegator storage delegator = delegators[msg.sender];
     require(delegator.delegateAddress == msg.sender);
     require(delegator.amountBonded > 0);
-    if (provider.status == ProviderStatus.Null) {
+    if (provider.status == ProviderStatus.Unregistered) {
       numberOfProviders = numberOfProviders.add(1);
       addProvider(msg.sender, provider.totalAmountBonded);
       // TODO: Fix warning
@@ -76,7 +75,7 @@ contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
   }
 
   function resignAsProvider() public {
-    require(providers[msg.sender].status != ProviderStatus.Null);
+    require(providers[msg.sender].status != ProviderStatus.Unregistered);
     delete providers[msg.sender];
     ProviderResigned(msg.sender);
   }
@@ -85,7 +84,7 @@ contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
     Provider storage provider = providers[_providerAddress];
     // A delegator is only allowed to bond to an Unregistered provider if the provider is himself
     // otherwise _providerAddress has to be associated with a Registered provider
-    require(_providerAddress == msg.sender || provider.status != ProviderStatus.Null);
+    require(_providerAddress == msg.sender || provider.status != ProviderStatus.Unregistered);
     // Check if delegator has not already bonded to some address
     require(delegators[msg.sender].delegateAddress == address(0));
     this.transferFrom(msg.sender, this, _amount);

--- a/contracts/ProviderRound.sol
+++ b/contracts/ProviderRound.sol
@@ -61,11 +61,10 @@ contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
     if (provider.status == ProviderStatus.Unregistered) {
       numberOfProviders = numberOfProviders.add(1);
       addProvider(msg.sender, provider.totalAmountBonded);
-      // TODO: Fix warning
-      ProviderAdded(msg.sender, _pricePerStorageMineral, _pricePerComputeMineral, _blockRewardCut, _feeShare);
+      emit ProviderAdded(msg.sender, _pricePerStorageMineral, _pricePerComputeMineral, _blockRewardCut, _feeShare);
     } else {
       updateProvider(msg.sender, provider.totalAmountBonded);
-      ProviderUpdated(msg.sender, _pricePerStorageMineral, _pricePerComputeMineral, _blockRewardCut, _feeShare);
+      emit ProviderUpdated(msg.sender, _pricePerStorageMineral, _pricePerComputeMineral, _blockRewardCut, _feeShare);
     }
     provider.status = ProviderStatus.Registered;
     provider.pricePerStorageMineral = _pricePerStorageMineral;
@@ -77,7 +76,7 @@ contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
   function resignAsProvider() public {
     require(providers[msg.sender].status != ProviderStatus.Unregistered);
     delete providers[msg.sender];
-    ProviderResigned(msg.sender);
+    emit ProviderResigned(msg.sender);
   }
 
   function bond(address _providerAddress, uint _amount) external {

--- a/contracts/ProviderRound.sol
+++ b/contracts/ProviderRound.sol
@@ -60,7 +60,7 @@ contract ProviderRound is TransmuteToken, RoundManager, ProviderPool {
     require(delegator.amountBonded > 0);
     if (provider.status == ProviderStatus.Null) {
       numberOfProviders = numberOfProviders.add(1);
-      //addProvider(msg.sender, 0);
+      addProvider(msg.sender, provider.totalAmountBonded);
       ProviderAdded(msg.sender, _pricePerStorageMineral, _pricePerComputeMineral, _blockRewardCut, _feeShare);
     } else {
       ProviderUpdated(msg.sender, _pricePerStorageMineral, _pricePerComputeMineral, _blockRewardCut, _feeShare);

--- a/contracts/SortedDoublyLL.sol
+++ b/contracts/SortedDoublyLL.sol
@@ -15,327 +15,327 @@ import "zeppelin-solidity/contracts/math/SafeMath.sol";
  * to find the appropriate insert position.
  */
 library SortedDoublyLL {
-    using SafeMath for uint256;
+  using SafeMath for uint256;
 
-    // Information for a node in the list
-    struct Node {
-        uint256 key;                     // Node's key used for sorting
-        address nextId;                  // Id of next node (smaller key) in the list
-        address prevId;                  // Id of previous node (larger key) in the list
+  // Information for a node in the list
+  struct Node {
+    uint256 key;                     // Node's key used for sorting
+    address nextId;                  // Id of next node (smaller key) in the list
+    address prevId;                  // Id of previous node (larger key) in the list
+  }
+
+  // Information for the list
+  struct Data {
+    address head;                        // Head of the list. Also the node in the list with the largest key
+    address tail;                        // Tail of the list. Also the node in the list with the smallest key
+    uint256 maxSize;                     // Maximum size of the list
+    uint256 size;                        // Current size of the list
+    mapping (address => Node) nodes;     // Track the corresponding ids for each node in the list
+  }
+
+  /*
+  * @dev Set the maximum size of the list
+  * @param _size Maximum size
+  */
+  function setMaxSize(Data storage self, uint256 _size) public {
+    // New max size must be greater than old max size
+    require(_size > self.maxSize);
+
+    self.maxSize = _size;
+  }
+
+  /*
+  * @dev Add a node to the list
+  * @param _id Node's id
+  * @param _key Node's key
+  * @param _prevId Id of previous node for the insert position
+  * @param _nextId Id of next node for the insert position
+    */
+  function insert(Data storage self, address _id, uint256 _key, address _prevId, address _nextId) public {
+    // List must not be full
+    require(!isFull(self));
+    // List must not already contain node
+    require(!contains(self, _id));
+    // Node id must not be null
+    require(_id != address(0));
+    // Key must be non-zero
+    require(_key > 0);
+
+    address prevId = _prevId;
+    address nextId = _nextId;
+
+    if (!validInsertPosition(self, _key, prevId, nextId)) {
+      // Sender's hint was not a valid insert position
+      // Use sender's hint to find a valid insert position
+      (prevId, nextId) = findInsertPosition(self, _key, prevId, nextId);
     }
 
-    // Information for the list
-    struct Data {
-        address head;                        // Head of the list. Also the node in the list with the largest key
-        address tail;                        // Tail of the list. Also the node in the list with the smallest key
-        uint256 maxSize;                     // Maximum size of the list
-        uint256 size;                        // Current size of the list
-        mapping (address => Node) nodes;     // Track the corresponding ids for each node in the list
+    self.nodes[_id].key = _key;
+
+    if (prevId == address(0) && nextId == address(0)) {
+      // Insert as head and tail
+      self.head = _id;
+      self.tail = _id;
+    } else if (prevId == address(0)) {
+      // Insert before `prevId` as the head
+      self.nodes[_id].nextId = self.head;
+      self.nodes[self.head].prevId = _id;
+      self.head = _id;
+    } else if (nextId == address(0)) {
+      // Insert after `nextId` as the tail
+      self.nodes[_id].prevId = self.tail;
+      self.nodes[self.tail].nextId = _id;
+      self.tail = _id;
+    } else {
+      // Insert at insert position between `prevId` and `nextId`
+      self.nodes[_id].nextId = nextId;
+      self.nodes[_id].prevId = prevId;
+      self.nodes[prevId].nextId = _id;
+      self.nodes[nextId].prevId = _id;
     }
 
-    /*
-     * @dev Set the maximum size of the list
-     * @param _size Maximum size
-     */
-    function setMaxSize(Data storage self, uint256 _size) public {
-        // New max size must be greater than old max size
-        require(_size > self.maxSize);
+    self.size = self.size.add(1);
+  }
 
-        self.maxSize = _size;
+  /*
+  * @dev Remove a node from the list
+  * @param _id Node's id
+  */
+  function remove(Data storage self, address _id) public {
+    // List must contain the node
+    require(contains(self, _id));
+
+    if (self.size > 1) {
+      // List contains more than a single node
+      if (_id == self.head) {
+        // The removed node is the head
+        // Set head to next node
+        self.head = self.nodes[_id].nextId;
+        // Set prev pointer of new head to null
+        self.nodes[self.head].prevId = address(0);
+      } else if (_id == self.tail) {
+        // The removed node is the tail
+        // Set tail to previous node
+        self.tail = self.nodes[_id].prevId;
+        // Set next pointer of new tail to null
+        self.nodes[self.tail].nextId = address(0);
+      } else {
+        // The removed node is neither the head nor the tail
+        // Set next pointer of previous node to the next node
+        self.nodes[self.nodes[_id].prevId].nextId = self.nodes[_id].nextId;
+        // Set prev pointer of next node to the previous node
+        self.nodes[self.nodes[_id].nextId].prevId = self.nodes[_id].prevId;
+      }
+    } else {
+      // List contains a single node
+      // Set the head and tail to null
+      self.head = address(0);
+      self.tail = address(0);
     }
 
-    /*
-     * @dev Add a node to the list
-     * @param _id Node's id
-     * @param _key Node's key
-     * @param _prevId Id of previous node for the insert position
-     * @param _nextId Id of next node for the insert position
-     */
-    function insert(Data storage self, address _id, uint256 _key, address _prevId, address _nextId) public {
-        // List must not be full
-        require(!isFull(self));
-        // List must not already contain node
-        require(!contains(self, _id));
-        // Node id must not be null
-        require(_id != address(0));
-        // Key must be non-zero
-        require(_key > 0);
+    delete self.nodes[_id];
+    self.size = self.size.sub(1);
+  }
 
-        address prevId = _prevId;
-        address nextId = _nextId;
+  /*
+  * @dev Update the key of a node in the list
+  * @param _id Node's id
+  * @param _newKey Node's new key
+  * @param _prevId Id of previous node for the new insert position
+  * @param _nextId Id of next node for the new insert position
+    */
+  function updateKey(Data storage self, address _id, uint256 _newKey, address _prevId, address _nextId) public {
+    // List must contain the node
+    require(contains(self, _id));
 
-        if (!validInsertPosition(self, _key, prevId, nextId)) {
-            // Sender's hint was not a valid insert position
-            // Use sender's hint to find a valid insert position
-            (prevId, nextId) = findInsertPosition(self, _key, prevId, nextId);
-        }
+    // Remove node from the list
+    remove(self, _id);
 
-        self.nodes[_id].key = _key;
+    if (_newKey > 0) {
+      // Insert node if it has a non-zero key
+      insert(self, _id, _newKey, _prevId, _nextId);
+    }
+  }
 
-        if (prevId == address(0) && nextId == address(0)) {
-            // Insert as head and tail
-            self.head = _id;
-            self.tail = _id;
-        } else if (prevId == address(0)) {
-            // Insert before `prevId` as the head
-            self.nodes[_id].nextId = self.head;
-            self.nodes[self.head].prevId = _id;
-            self.head = _id;
-        } else if (nextId == address(0)) {
-            // Insert after `nextId` as the tail
-            self.nodes[_id].prevId = self.tail;
-            self.nodes[self.tail].nextId = _id;
-            self.tail = _id;
-        } else {
-            // Insert at insert position between `prevId` and `nextId`
-            self.nodes[_id].nextId = nextId;
-            self.nodes[_id].prevId = prevId;
-            self.nodes[prevId].nextId = _id;
-            self.nodes[nextId].prevId = _id;
-        }
+  /*
+  * @dev Checks if the list contains a node
+  * @param _transcoder Address of transcoder
+  */
+  function contains(Data storage self, address _id) public view returns (bool) {
+    // List only contains non-zero keys, so if key is non-zero the node exists
+    return self.nodes[_id].key > 0;
+  }
 
-        self.size = self.size.add(1);
+  /*
+  * @dev Checks if the list is full
+  */
+  function isFull(Data storage self) public view returns (bool) {
+    return self.size == self.maxSize;
+  }
+
+  /*
+  * @dev Checks if the list is empty
+  */
+  function isEmpty(Data storage self) public view returns (bool) {
+    return self.size == 0;
+  }
+
+  /*
+  * @dev Returns the current size of the list
+  */
+  function getSize(Data storage self) public view returns (uint256) {
+    return self.size;
+  }
+
+  /*
+  * @dev Returns the maximum size of the list
+  */
+  function getMaxSize(Data storage self) public view returns (uint256) {
+    return self.maxSize;
+  }
+
+  /*
+  * @dev Returns the key of a node in the list
+  * @param _id Node's id
+  */
+  function getKey(Data storage self, address _id) public view returns (uint256) {
+    return self.nodes[_id].key;
+  }
+
+  /*
+  * @dev Returns the first node in the list (node with the largest key)
+  */
+  function getFirst(Data storage self) public view returns (address) {
+    return self.head;
+  }
+
+  /*
+  * @dev Returns the last node in the list (node with the smallest key)
+  */
+  function getLast(Data storage self) public view returns (address) {
+    return self.tail;
+  }
+
+  /*
+  * @dev Returns the next node (with a smaller key) in the list for a given node
+  * @param _id Node's id
+  */
+  function getNext(Data storage self, address _id) public view returns (address) {
+    return self.nodes[_id].nextId;
+  }
+
+  /*
+  * @dev Returns the previous node (with a larger key) in the list for a given node
+  * @param _id Node's id
+  */
+  function getPrev(Data storage self, address _id) public view returns (address) {
+    return self.nodes[_id].prevId;
+  }
+
+  /*
+  * @dev Check if a pair of nodes is a valid insertion point for a new node with the given key
+  * @param _key Node's key
+  * @param _prevId Id of previous node for the insert position
+    * @param _nextId Id of next node for the insert position
+      */
+  function validInsertPosition(Data storage self, uint256 _key, address _prevId, address _nextId) public view returns (bool) {
+    if (_prevId == address(0) && _nextId == address(0)) {
+      // `(null, null)` is a valid insert position if the list is empty
+      return isEmpty(self);
+    } else if (_prevId == address(0)) {
+      // `(null, _nextId)` is a valid insert position if `_nextId` is the head of the list
+      return self.head == _nextId && _key >= self.nodes[_nextId].key;
+    } else if (_nextId == address(0)) {
+      // `(_prevId, null)` is a valid insert position if `_prevId` is the tail of the list
+      return self.tail == _prevId && _key <= self.nodes[_prevId].key;
+    } else {
+      // `(_prevId, _nextId)` is a valid insert position if they are adjacent nodes and `_key` falls between the two nodes' keys
+      return self.nodes[_prevId].nextId == _nextId && self.nodes[_prevId].key >= _key && _key >= self.nodes[_nextId].key;
+    }
+  }
+
+  /*
+  * @dev Descend the list (larger keys to smaller keys) to find a valid insert position
+  * @param _key Node's key
+  * @param _startId Id of node to start ascending the list from
+  */
+  function descendList(Data storage self, uint256 _key, address _startId) private view returns (address, address) {
+    // If `_startId` is the head, check if the insert position is before the head
+    if (self.head == _startId && _key >= self.nodes[_startId].key) {
+      return (address(0), _startId);
     }
 
-    /*
-     * @dev Remove a node from the list
-     * @param _id Node's id
-     */
-    function remove(Data storage self, address _id) public {
-        // List must contain the node
-        require(contains(self, _id));
+    address prevId = _startId;
+    address nextId = self.nodes[prevId].nextId;
 
-        if (self.size > 1) {
-            // List contains more than a single node
-            if (_id == self.head) {
-                // The removed node is the head
-                // Set head to next node
-                self.head = self.nodes[_id].nextId;
-                // Set prev pointer of new head to null
-                self.nodes[self.head].prevId = address(0);
-            } else if (_id == self.tail) {
-                // The removed node is the tail
-                // Set tail to previous node
-                self.tail = self.nodes[_id].prevId;
-                // Set next pointer of new tail to null
-                self.nodes[self.tail].nextId = address(0);
-            } else {
-                // The removed node is neither the head nor the tail
-                // Set next pointer of previous node to the next node
-                self.nodes[self.nodes[_id].prevId].nextId = self.nodes[_id].nextId;
-                // Set prev pointer of next node to the previous node
-                self.nodes[self.nodes[_id].nextId].prevId = self.nodes[_id].prevId;
-            }
-        } else {
-            // List contains a single node
-            // Set the head and tail to null
-            self.head = address(0);
-            self.tail = address(0);
-        }
-
-        delete self.nodes[_id];
-        self.size = self.size.sub(1);
+    // Descend the list until we reach the end or until we find a valid insert position
+    while (prevId != address(0) && !validInsertPosition(self, _key, prevId, nextId)) {
+      prevId = self.nodes[prevId].nextId;
+      nextId = self.nodes[prevId].nextId;
     }
 
-    /*
-     * @dev Update the key of a node in the list
-     * @param _id Node's id
-     * @param _newKey Node's new key
-     * @param _prevId Id of previous node for the new insert position
-     * @param _nextId Id of next node for the new insert position
-     */
-    function updateKey(Data storage self, address _id, uint256 _newKey, address _prevId, address _nextId) public {
-        // List must contain the node
-        require(contains(self, _id));
+    return (prevId, nextId);
+  }
 
-        // Remove node from the list
-        remove(self, _id);
-
-        if (_newKey > 0) {
-            // Insert node if it has a non-zero key
-            insert(self, _id, _newKey, _prevId, _nextId);
-        }
+  /*
+  * @dev Ascend the list (smaller keys to larger keys) to find a valid insert position
+  * @param _key Node's key
+  * @param _startId Id of node to start descending the list from
+  */
+  function ascendList(Data storage self, uint256 _key, address _startId) private view returns (address, address) {
+    // If `_startId` is the tail, check if the insert position is after the tail
+    if (self.tail == _startId && _key <= self.nodes[_startId].key) {
+      return (_startId, address(0));
     }
 
-    /*
-     * @dev Checks if the list contains a node
-     * @param _transcoder Address of transcoder
-     */
-    function contains(Data storage self, address _id) public view returns (bool) {
-        // List only contains non-zero keys, so if key is non-zero the node exists
-        return self.nodes[_id].key > 0;
+    address nextId = _startId;
+    address prevId = self.nodes[nextId].prevId;
+
+    // Ascend the list until we reach the end or until we find a valid insertion point
+    while (nextId != address(0) && !validInsertPosition(self, _key, prevId, nextId)) {
+      nextId = self.nodes[nextId].prevId;
+      prevId = self.nodes[nextId].prevId;
     }
 
-    /*
-     * @dev Checks if the list is full
-     */
-    function isFull(Data storage self) public view returns (bool) {
-        return self.size == self.maxSize;
+    return (prevId, nextId);
+  }
+
+  /*
+  * @dev Find the insert position for a new node with the given key
+  * @param _key Node's key
+  * @param _prevId Id of previous node for the insert position
+    * @param _nextId Id of next node for the insert position
+      */
+  function findInsertPosition(Data storage self, uint256 _key, address _prevId, address _nextId) private view returns (address, address) {
+    address prevId = _prevId;
+    address nextId = _nextId;
+
+    if (prevId != address(0)) {
+      if (!contains(self, prevId) || _key > self.nodes[prevId].key) {
+        // `prevId` does not exist anymore or now has a smaller key than the given key
+        prevId = address(0);
+      }
     }
 
-    /*
-     * @dev Checks if the list is empty
-     */
-    function isEmpty(Data storage self) public view returns (bool) {
-        return self.size == 0;
+    if (nextId != address(0)) {
+      if (!contains(self, nextId) || _key < self.nodes[nextId].key) {
+        // `nextId` does not exist anymore or now has a larger key than the given key
+        nextId = address(0);
+      }
     }
 
-    /*
-     * @dev Returns the current size of the list
-     */
-    function getSize(Data storage self) public view returns (uint256) {
-        return self.size;
+    if (prevId == address(0) && nextId == address(0)) {
+      // No hint - descend list starting from head
+      return descendList(self, _key, self.head);
+    } else if (prevId == address(0)) {
+      // No `prevId` for hint - ascend list starting from `nextId`
+      return ascendList(self, _key, nextId);
+    } else if (nextId == address(0)) {
+      // No `nextId` for hint - descend list starting from `prevId`
+      return descendList(self, _key, prevId);
+    } else {
+      // Descend list starting from `prevId`
+      return descendList(self, _key, prevId);
     }
-
-    /*
-     * @dev Returns the maximum size of the list
-     */
-    function getMaxSize(Data storage self) public view returns (uint256) {
-        return self.maxSize;
-    }
-
-    /*
-     * @dev Returns the key of a node in the list
-     * @param _id Node's id
-     */
-    function getKey(Data storage self, address _id) public view returns (uint256) {
-        return self.nodes[_id].key;
-    }
-
-    /*
-     * @dev Returns the first node in the list (node with the largest key)
-     */
-    function getFirst(Data storage self) public view returns (address) {
-        return self.head;
-    }
-
-    /*
-     * @dev Returns the last node in the list (node with the smallest key)
-     */
-    function getLast(Data storage self) public view returns (address) {
-        return self.tail;
-    }
-
-    /*
-     * @dev Returns the next node (with a smaller key) in the list for a given node
-     * @param _id Node's id
-     */
-    function getNext(Data storage self, address _id) public view returns (address) {
-        return self.nodes[_id].nextId;
-    }
-
-    /*
-     * @dev Returns the previous node (with a larger key) in the list for a given node
-     * @param _id Node's id
-     */
-    function getPrev(Data storage self, address _id) public view returns (address) {
-        return self.nodes[_id].prevId;
-    }
-
-    /*
-     * @dev Check if a pair of nodes is a valid insertion point for a new node with the given key
-     * @param _key Node's key
-     * @param _prevId Id of previous node for the insert position
-     * @param _nextId Id of next node for the insert position
-     */
-    function validInsertPosition(Data storage self, uint256 _key, address _prevId, address _nextId) public view returns (bool) {
-        if (_prevId == address(0) && _nextId == address(0)) {
-            // `(null, null)` is a valid insert position if the list is empty
-            return isEmpty(self);
-        } else if (_prevId == address(0)) {
-            // `(null, _nextId)` is a valid insert position if `_nextId` is the head of the list
-            return self.head == _nextId && _key >= self.nodes[_nextId].key;
-        } else if (_nextId == address(0)) {
-            // `(_prevId, null)` is a valid insert position if `_prevId` is the tail of the list
-            return self.tail == _prevId && _key <= self.nodes[_prevId].key;
-        } else {
-            // `(_prevId, _nextId)` is a valid insert position if they are adjacent nodes and `_key` falls between the two nodes' keys
-            return self.nodes[_prevId].nextId == _nextId && self.nodes[_prevId].key >= _key && _key >= self.nodes[_nextId].key;
-        }
-    }
-
-    /*
-     * @dev Descend the list (larger keys to smaller keys) to find a valid insert position
-     * @param _key Node's key
-     * @param _startId Id of node to start ascending the list from
-     */
-    function descendList(Data storage self, uint256 _key, address _startId) private view returns (address, address) {
-        // If `_startId` is the head, check if the insert position is before the head
-        if (self.head == _startId && _key >= self.nodes[_startId].key) {
-            return (address(0), _startId);
-        }
-
-        address prevId = _startId;
-        address nextId = self.nodes[prevId].nextId;
-
-        // Descend the list until we reach the end or until we find a valid insert position
-        while (prevId != address(0) && !validInsertPosition(self, _key, prevId, nextId)) {
-            prevId = self.nodes[prevId].nextId;
-            nextId = self.nodes[prevId].nextId;
-        }
-
-        return (prevId, nextId);
-    }
-
-    /*
-     * @dev Ascend the list (smaller keys to larger keys) to find a valid insert position
-     * @param _key Node's key
-     * @param _startId Id of node to start descending the list from
-     */
-    function ascendList(Data storage self, uint256 _key, address _startId) private view returns (address, address) {
-        // If `_startId` is the tail, check if the insert position is after the tail
-        if (self.tail == _startId && _key <= self.nodes[_startId].key) {
-            return (_startId, address(0));
-        }
-
-        address nextId = _startId;
-        address prevId = self.nodes[nextId].prevId;
-
-        // Ascend the list until we reach the end or until we find a valid insertion point
-        while (nextId != address(0) && !validInsertPosition(self, _key, prevId, nextId)) {
-            nextId = self.nodes[nextId].prevId;
-            prevId = self.nodes[nextId].prevId;
-        }
-
-        return (prevId, nextId);
-    }
-
-    /*
-     * @dev Find the insert position for a new node with the given key
-     * @param _key Node's key
-     * @param _prevId Id of previous node for the insert position
-     * @param _nextId Id of next node for the insert position
-     */
-    function findInsertPosition(Data storage self, uint256 _key, address _prevId, address _nextId) private view returns (address, address) {
-        address prevId = _prevId;
-        address nextId = _nextId;
-
-        if (prevId != address(0)) {
-            if (!contains(self, prevId) || _key > self.nodes[prevId].key) {
-                // `prevId` does not exist anymore or now has a smaller key than the given key
-                prevId = address(0);
-            }
-        }
-
-        if (nextId != address(0)) {
-            if (!contains(self, nextId) || _key < self.nodes[nextId].key) {
-                // `nextId` does not exist anymore or now has a larger key than the given key
-                nextId = address(0);
-            }
-        }
-
-        if (prevId == address(0) && nextId == address(0)) {
-            // No hint - descend list starting from head
-            return descendList(self, _key, self.head);
-        } else if (prevId == address(0)) {
-            // No `prevId` for hint - ascend list starting from `nextId`
-            return ascendList(self, _key, nextId);
-        } else if (nextId == address(0)) {
-            // No `nextId` for hint - descend list starting from `prevId`
-            return descendList(self, _key, prevId);
-        } else {
-            // Descend list starting from `prevId`
-            return descendList(self, _key, prevId);
-        }
-    }
+  }
 }

--- a/contracts/TestProviderPool.sol
+++ b/contracts/TestProviderPool.sol
@@ -8,5 +8,10 @@ contract TestProviderPool is ProviderPool {
   function publicAddProvider(address _providerAddress, uint _bondedAmount) public {
     addProvider(_providerAddress, _bondedAmount);
   }
+
+  // @dev convenience method to be able to call updateProvider from web3js (it has internal visibility)
+  function publicUpdateProvider(address _providerAddress, uint _bondedAmount) public {
+    updateProvider(_providerAddress, _bondedAmount);
+  }
 }
 

--- a/contracts/TestProviderPool.sol
+++ b/contracts/TestProviderPool.sol
@@ -3,10 +3,6 @@ pragma solidity ^0.4.24;
 import "../contracts/ProviderPool.sol";
 
 contract TestProviderPool is ProviderPool {
-  // @dev convenience method to access from web3js the 'nodes' mapping that lives inside SortedDoublyLL.Data
-  function get(address _provider) returns (uint, address, address) {
-    return (providerPool.nodes[_provider].key, providerPool.nodes[_provider].nextId, providerPool.nodes[_provider].prevId);
-  }
 
   // @dev convenience method to be able to call addProvider from web3js (it has internal visibility)
   function publicAddProvider(address _providerAddress, uint _bondedAmount) public {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -6,9 +6,10 @@ const TestProviderPool = artifacts.require('./TestProviderPool.sol');
 
 module.exports = deployer => {
   deployer.deploy(TST);
+  deployer.deploy(SortedDoublyLL);
+  deployer.link(SortedDoublyLL, ProviderRound);
   deployer.deploy(ProviderRound);
   deployer.deploy(RoundManager);
-  deployer.deploy(SortedDoublyLL);
   deployer.link(SortedDoublyLL, TestProviderPool);
   deployer.deploy(TestProviderPool);
 };

--- a/test/TestProviderPool.spec.js
+++ b/test/TestProviderPool.spec.js
@@ -14,15 +14,15 @@ contract('ProviderPool', accounts => {
     let bondedAmountOfPreviousAddress = Number.POSITIVE_INFINITY;
     let previousAddress = 0;
     let providerPool = await pp.providerPool.call();
-    let currentAddress = providerPool[0];
+    let currentAddress = providerPool[0]; // [0] is head of the list
     let node = await pp.getProvider.call(currentAddress);
-    let end = providerPool[1];
+    let end = providerPool[1]; // [1] is tail of the list
     do {
-      assert(bondedAmountOfPreviousAddress >= node[0]);
-      assert.equal(node[2], previousAddress);
+      assert(bondedAmountOfPreviousAddress >= node[0]); // [0] is the bondedAmount
+      assert.equal(node[2], previousAddress); // [2] is previous address in the list
       bondedAmountOfPreviousAddress = node[0].toNumber();
       previousAddress = currentAddress;
-      currentAddress = node[1];
+      currentAddress = node[1]; // [1] is next address in the list
       node = await pp.getProvider.call(currentAddress);
     }
     while(currentAddress != end)

--- a/test/TestProviderPool.spec.js
+++ b/test/TestProviderPool.spec.js
@@ -86,5 +86,22 @@ contract('ProviderPool', accounts => {
       await assertFail( pp.publicAddProvider(accounts[8], 15) );
     });
   });
+
+  describe('containsProvider', () => {
+
+    before(async () => {
+      pp = await ProviderPool.new();
+      await pp.setMaxNumberOfProviders(10, {from: accounts[0]});
+    });
+
+    it('should return false if provider is not in the pool', async () => {
+      assert.equal(false, await pp.containsProvider(accounts[0]));
+    });
+
+    it('should return true if provider is in the pool', async () => {
+      await pp.publicAddProvider(accounts[0], 1);
+      assert.equal(true, await pp.containsProvider(accounts[0]));
+    });
+  });
 });
 

--- a/test/TestProviderPool.spec.js
+++ b/test/TestProviderPool.spec.js
@@ -51,14 +51,14 @@ contract('ProviderPool', accounts => {
         let previousAddress = 0;
         let providerPool = await pp.providerPool.call();
         let currentAddress = providerPool[0];
-        let node = await pp.get.call(currentAddress);
+        let node = await pp.getProvider.call(currentAddress);
         let end = providerPool[1];
         do {
           assert(node[0] <= bondedAmountOfPreviousAddress); //
           assert.equal(node[2], previousAddress);
           previousAddress = currentAddress;
           currentAddress = node[1];
-          node = await pp.get.call(currentAddress);
+          node = await pp.getProvider.call(currentAddress);
         }
         while(currentAddress != end)
       }

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -6,8 +6,10 @@ contract('ProviderRound', accounts => {
 
   let providerRound;
   let contractAddress;
+  const PROVIDER_POOL_SIZE = 10;
   const PROVIDER_NULL = 0;
   const PROVIDER_REGISTERED = 1;
+
 
   async function approveBondProvider(pricePerStorageMineral, pricePerComputeMineral, blockRewardCut, feeShare, amountBonded, providerAddress) {
       await providerRound.approve(contractAddress, amountBonded, {from: providerAddress});
@@ -23,6 +25,7 @@ contract('ProviderRound', accounts => {
       for(let i = 0; i < 5; i++) {
         await providerRound.mint(accounts[i], 1000, {from: accounts[0]});
       }
+      await providerRound.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
     });
 
     beforeEach(async () => {
@@ -116,6 +119,7 @@ contract('ProviderRound', accounts => {
       for(let i = 0; i < 5; i++) {
         await providerRound.mint(accounts[i], 1000, {from: accounts[0]});
       }
+      await providerRound.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
       await blockMiner.mineUntilEndOfElectionPeriod(providerRound);
       await providerRound.initializeRound();
       await approveBondProvider(22, 10, 1, 25, 1, accounts[0]);
@@ -158,6 +162,7 @@ contract('ProviderRound', accounts => {
       for(let i = 0; i < 10; i++) {
         await providerRound.mint(accounts[i], 1000, {from: accounts[0]});
       }
+      await providerRound.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
       await blockMiner.mineUntilEndOfElectionPeriod(providerRound);
       await providerRound.initializeRound();
       await approveBondProvider(22, 10, 1, 25, 1, accounts[0]);

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -123,7 +123,14 @@ contract('ProviderRound', accounts => {
     });
 
     it('should fail if provider is Unregistered and size == maxSize', async () => {
+      let providerPool = await providerRound.providerPool.call();
+      const maxSize = providerPool[2]; // [2] is maxSize
+      let currentSize = providerPool[3]; // [3] is current size
+      assert.isAbove(maxSize, currentSize);
       await approveBondProvider(20 ,10, 2, 25, 1, accounts[4]);
+      providerPool = await providerRound.providerPool.call();
+      currentSize = providerPool[3];
+      assert.deepEqual(maxSize, currentSize);
       await assertFail( approveBondProvider(20 ,10, 2, 25, 1, accounts[5]) );
     });
 
@@ -132,10 +139,10 @@ contract('ProviderRound', accounts => {
       assert.equal(true, await providerRound.containsProvider(accounts[3]));
       // Check the size of the pool stays the same
       let providerPool = await providerRound.providerPool.call();
-      const previousSize = providerPool[3].toNumber(); // [3] is current size of the pool
+      const previousSize = providerPool[3]; // [3] is current size of the pool
       await providerRound.provider(19, 10, 2, 20, {from: accounts[3]});
       providerPool = await providerRound.providerPool.call();
-      assert.equal(previousSize, providerPool[3]);
+      assert.deepEqual(previousSize, providerPool[3]);
     });
 
     it('should work if provider is Registered and size == maxSize', async () => {

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -70,7 +70,9 @@ contract('ProviderRound', accounts => {
 
     it('should work if called before the lock period of an active round', async () => {
       await blockMiner.mineUntilLastBlockBeforeLockPeriod(providerRound);
-      await providerRound.provider(22, 10, 1, 25, {from: accounts[0]});
+      await providerRound.provider(23, 10, 1, 25, {from: accounts[0]});
+      const provider = await providerRound.providers(accounts[0]);
+      assert.equal(23, provider[1]); // [1] is pricePerStorageMineral
     });
 
     it('should fail during the lock period of an active round', async () => {

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -5,13 +5,24 @@ require('truffle-test-utils').init();
 contract('ProviderRound', accounts => {
 
   let providerRound;
+  let contractAddress;
   const PROVIDER_NULL = 0;
   const PROVIDER_REGISTERED = 1;
+
+  async function approveBondProvider(pricePerStorageMineral, pricePerComputeMineral, blockRewardCut, feeShare, amountBonded, providerAddress) {
+      await providerRound.approve(contractAddress, amountBonded, {from: providerAddress});
+      await providerRound.bond(providerAddress, amountBonded, {from: providerAddress});
+      await providerRound.provider(pricePerStorageMineral, pricePerComputeMineral, blockRewardCut, feeShare, {from: providerAddress});
+  }
 
   describe('provider', () => {
 
     before(async () => {
       providerRound = await ProviderRound.deployed();
+      contractAddress = providerRound.address;
+      for(let i = 0; i < 5; i++) {
+        await providerRound.mint(accounts[i], 1000, {from: accounts[0]});
+      }
     });
 
     beforeEach(async () => {
@@ -20,25 +31,18 @@ contract('ProviderRound', accounts => {
     });
 
     it("should register a provider's parameters", async () => {
-      await providerRound.provider(22, 10, 1, 25, {from: accounts[0]});
-      await providerRound.provider(10, 20, 2, 35, {from: accounts[1]});
-      const firstProvider = await providerRound.providers.call(accounts[0]);
-      assert.equal(firstProvider[0], PROVIDER_REGISTERED); // [0] is providerStatus
-      assert.equal(firstProvider[1].toNumber(), 22); // [1] is pricePerStorageMineral
-      assert.equal(firstProvider[2].toNumber(), 10); // [2] is pricePerComputeMineral
-      assert.equal(firstProvider[3].toNumber(), 1);  // [3] is blockRewardCut
-      assert.equal(firstProvider[4].toNumber(), 25); // [4] is feeShare
-      const secondProvider = await providerRound.providers.call(accounts[1]);
-      assert.equal(secondProvider[0], PROVIDER_REGISTERED); // [0] is providerStatus
-      assert.equal(secondProvider[1].toNumber(), 10); // [1] is pricePerStorageMineral
-      assert.equal(secondProvider[2].toNumber(), 20); // [2] is pricePerComputeMineral
-      assert.equal(secondProvider[3].toNumber(), 2);  // [3] is blockRewardCut
-      assert.equal(secondProvider[4].toNumber(), 35); // [4] is feeShare
+      await approveBondProvider(10, 20, 2, 35, 1, accounts[1]);
+      const provider = await providerRound.providers.call(accounts[1]);
+      assert.equal(provider[0], PROVIDER_REGISTERED); // [0] is providerStatus
+      assert.equal(provider[1].toNumber(), 10); // [1] is pricePerStorageMineral
+      assert.equal(provider[2].toNumber(), 20); // [2] is pricePerComputeMineral
+      assert.equal(provider[3].toNumber(), 2);  // [3] is blockRewardCut
+      assert.equal(provider[4].toNumber(), 35); // [4] is feeShare
     });
 
     it('should fail with invalid parameters', async() => {
       await assertFail(
-        providerRound.provider(22, 10, -1, 25, {from: accounts[2]}),
+        approveBondProvider(22, 10, -1, 25, 1, accounts[2]),
         'provider should not be able to have a negative blockRewardCut'
       );
       await assertFail(
@@ -47,34 +51,29 @@ contract('ProviderRound', accounts => {
       );
     });
 
-    it('should set totalBondedAmount to 0', async () => {
-      const firstProvider = await providerRound.providers.call(accounts[0]);
-      assert.equal(0, firstProvider[5]); // [5] is totalBondedAmount
-    });
-
     it('should fail if not called during an active round', async () => {
       await blockMiner.mineUntilEndOfElectionPeriod(providerRound);
-      await assertFail( providerRound.provider(22, 10, 1, 25) );
+      await assertFail( providerRound.provider(22, 10, 1, 25, {from: accounts[0]}) );
     });
 
-    it('should register parameters before the lock period of an active round', async () => {
+    it('should work if called before the lock period of an active round', async () => {
       await blockMiner.mineUntilLastBlockBeforeLockPeriod(providerRound);
-      await providerRound.provider(22, 10, 1, 25);
+      await providerRound.provider(22, 10, 1, 25, {from: accounts[0]});
     });
 
     it('should fail during the lock period of an active round', async () => {
       await blockMiner.mineUntilLastBlockBeforeLockPeriod(providerRound);
       // Enter lock period
       await blockMiner.mine(1);
-      await assertFail( providerRound.provider(22, 10, 1, 25) );
+      await assertFail( providerRound.provider(22, 10, 1, 25, {from: accounts[0]}) );
     });
 
     it('should send a ProviderAdded event for a new provider', async () => {
-      const result = await providerRound.provider(22, 10, 1, 25, {from: accounts[3]});
+      const result = await providerRound.provider(22, 10, 1, 25, {from: accounts[2]});
       assert.web3Event(result, {
         event: 'ProviderAdded',
         args: {
-          _providerAddress: accounts[3],
+          _providerAddress: accounts[2],
           _pricePerStorageMineral: 22,
           _pricePerComputeMineral: 10,
           _blockRewardCut: 1,
@@ -84,11 +83,11 @@ contract('ProviderRound', accounts => {
     });
 
     it('should send a ProviderUpdated event for an existing provider', async () => {
-      const result = await providerRound.provider(21, 11, 2, 24, {from: accounts[3]});
+      const result = await providerRound.provider(21, 11, 2, 24, {from: accounts[2]});
       assert.web3Event(result, {
         event: 'ProviderUpdated',
         args: {
-          _providerAddress: accounts[3],
+          _providerAddress: accounts[2],
           _pricePerStorageMineral: 21,
           _pricePerComputeMineral: 11,
           _blockRewardCut: 2,
@@ -103,12 +102,17 @@ contract('ProviderRound', accounts => {
 
     before(async () => {
       providerRound = await ProviderRound.new();
+      contractAddress = providerRound.address;
+      for(let i = 0; i < 5; i++) {
+        await providerRound.mint(accounts[i], 1000, {from: accounts[0]});
+      }
       await blockMiner.mineUntilEndOfElectionPeriod(providerRound);
       await providerRound.initializeRound();
+      await approveBondProvider(22, 10, 1, 25, 1, accounts[0]);
+      await approveBondProvider(22, 10, 1, 25, 1, accounts[1]);
     });
 
     it('should remove a provider from the provider mapping', async () => {
-      await providerRound.provider(22, 10, 1, 25, {from: accounts[0]});
       const registeredProvider = await providerRound.providers.call(accounts[0]);
       assert.equal(PROVIDER_REGISTERED, registeredProvider[0]); // [0] is providerStatus
       await providerRound.resignAsProvider({from: accounts[0]});
@@ -122,7 +126,6 @@ contract('ProviderRound', accounts => {
     });
 
     it('should send a ProviderResigned event', async () => {
-      await providerRound.provider(22, 10, 1, 25, {from: accounts[1]});
       const result = await providerRound.resignAsProvider({from: accounts[1]});
       assert.web3Event(result, {
         event: 'ProviderResigned',
@@ -133,24 +136,22 @@ contract('ProviderRound', accounts => {
     });
 
     it("should fail if the transaction's sender is not a provider", async () => {
-      await assertFail( providerRound.resignAsProvider({from: accounts[1]}) );
+      await assertFail( providerRound.resignAsProvider({from: accounts[2]}) );
     });
   });
 
   describe('bond', () => {
 
-    let contractAddress;
-
     before(async () => {
-      providerRound = await ProviderRound.new({from: accounts[0]});
+      providerRound = await ProviderRound.new();
       contractAddress = providerRound.address;
-      for(let i = 5; i < 10; i++) {
+      for(let i = 0; i < 10; i++) {
         await providerRound.mint(accounts[i], 1000, {from: accounts[0]});
       }
       await blockMiner.mineUntilEndOfElectionPeriod(providerRound);
       await providerRound.initializeRound();
-      await providerRound.provider(22, 10, 1, 25, {from: accounts[0]});
-      await providerRound.provider(10, 20, 2, 35, {from: accounts[1]});
+      await approveBondProvider(22, 10, 1, 25, 1, accounts[0]);
+      await approveBondProvider(10, 20, 2, 35, 1, accounts[1]);
     });
 
     it('should fail if the delegator does not approve to transfer at least the bonded amount', async () => {
@@ -169,15 +170,15 @@ contract('ProviderRound', accounts => {
 
     it('should increase the totalAmountBonded of the provider', async () => {
       let firstProvider = await providerRound.providers.call(accounts[0]);
-      assert.equal(10, firstProvider[5]);
+      assert.equal(11, firstProvider[5]);
       await providerRound.approve(contractAddress, 20, {from: accounts[6]});
       await providerRound.bond(accounts[1], 20, {from: accounts[6]});
       await providerRound.approve(contractAddress, 50, {from: accounts[7]});
       await providerRound.bond(accounts[1], 50, {from: accounts[7]});
       firstProvider = await providerRound.providers.call(accounts[0]);
       const secondProvider = await providerRound.providers.call(accounts[1]);
-      assert.equal(10, firstProvider[5]); // [5] is totalAmountBonded
-      assert.equal(70, secondProvider[5]); // [5] is totalAmountBonded
+      assert.equal(11, firstProvider[5]); // [5] is totalAmountBonded
+      assert.equal(71, secondProvider[5]); // [5] is totalAmountBonded
     });
 
     it('should fail if no providerCandidate is associated with the given providerCandidateId', async () => {
@@ -193,7 +194,7 @@ contract('ProviderRound', accounts => {
     it('should fail if TST balance is less than bonded amount', async () => {
       await providerRound.approve(contractAddress, 1001, {from: accounts[9]});
       await assertFail( providerRound.bond(accounts[1], 1001, {from: accounts[9]}) )
-      assert.equal(110, (await providerRound.providers(accounts[1]))[5]);
+      assert.equal(111, (await providerRound.providers(accounts[1]))[5]);
     });
 
     it("should transfer amount from the delegator's balance to the contract's balance", async () => {

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -131,13 +131,13 @@ contract('ProviderRound', accounts => {
 
     it('should fail if provider is Unregistered and size == maxSize', async () => {
       let providerPool = await providerRound.providerPool.call();
-      const maxSize = providerPool[2].toNumber(); // [2] is maxSize
+      const maxSize = providerPool[2]; // [2] is maxSize
       let currentSize = providerPool[3]; // [3] is current size
       assert.isAbove(maxSize, currentSize);
       await approveBondProvider(20 ,10, 2, 25, 1, accounts[4]);
       providerPool = await providerRound.providerPool.call();
       currentSize = providerPool[3];
-      assert.equal(maxSize, currentSize);
+      assert.deepEqual(maxSize, currentSize);
       await assertFail( approveBondProvider(20 ,10, 2, 25, 1, accounts[5]) );
     });
 

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -241,7 +241,7 @@ contract('ProviderRound', accounts => {
     it('should fail if TST balance is less than bonded amount', async () => {
       await providerRound.approve(contractAddress, 1001, {from: accounts[9]});
       await assertFail( providerRound.bond(accounts[1], 1001, {from: accounts[9]}) )
-      assert.equal(21, (await providerRound.providers(accounts[1]))[5]);
+      assert(1001 >= (await providerRound.providers(accounts[1]))[5]);
     });
 
     it("should transfer amount from the delegator's balance to the contract's balance", async () => {

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -7,7 +7,7 @@ contract('ProviderRound', accounts => {
   let providerRound;
   let contractAddress;
   const PROVIDER_POOL_SIZE = 5;
-  const PROVIDER_NULL = 0;
+  const PROVIDER_UNREGISTERED = 0;
   const PROVIDER_REGISTERED = 1;
 
   async function approveBondProvider(pricePerStorageMineral, pricePerComputeMineral, blockRewardCut, feeShare, amountBonded, providerAddress) {
@@ -163,7 +163,7 @@ contract('ProviderRound', accounts => {
       assert.equal(PROVIDER_REGISTERED, registeredProvider[0]); // [0] is providerStatus
       await providerRound.resignAsProvider({from: accounts[0]});
       const resignedProvider = await providerRound.providers.call(accounts[0]);
-      assert.equal(PROVIDER_NULL, resignedProvider[0]); // [0] is providerStatus
+      assert.equal(PROVIDER_UNREGISTERED, resignedProvider[0]); // [0] is providerStatus
       assert.equal(0, resignedProvider[1]); // [1] is pricePerStorageMineral
       assert.equal(0, resignedProvider[2]); // [2] is pricePerComputeMineral
       assert.equal(0, resignedProvider[3]); // [3] is blockRewardCut

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -133,7 +133,7 @@ contract('ProviderRound', accounts => {
       let providerPool = await providerRound.providerPool.call();
       const maxSize = providerPool[2]; // [2] is maxSize
       let currentSize = providerPool[3]; // [3] is current size
-      assert.isAbove(maxSize, currentSize);
+      assert.isAbove(maxSize, currentSize.toNumber());
       await approveBondProvider(20 ,10, 2, 25, 1, accounts[4]);
       providerPool = await providerRound.providerPool.call();
       currentSize = providerPool[3];

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -10,7 +10,12 @@ contract('ProviderRound', accounts => {
   const PROVIDER_UNREGISTERED = 0;
   const PROVIDER_REGISTERED = 1;
 
+  // This is a convenience function for the process of registering a new provider.
+  // Step 1: Approve the transfer of amountBonded tokens (ERC20 spec)
+  // Step 2: Bond the amount to the provider
+  // Step 3: Registering parameters with provider()
   async function approveBondProvider(pricePerStorageMineral, pricePerComputeMineral, blockRewardCut, feeShare, amountBonded, providerAddress) {
+      // This approve function comes from the ERC20 Transmute Token contract
       await providerRound.approve(contractAddress, amountBonded, {from: providerAddress});
       await providerRound.bond(providerAddress, amountBonded, {from: providerAddress});
       await providerRound.provider(pricePerStorageMineral, pricePerComputeMineral, blockRewardCut, feeShare, {from: providerAddress});

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -6,10 +6,9 @@ contract('ProviderRound', accounts => {
 
   let providerRound;
   let contractAddress;
-  const PROVIDER_POOL_SIZE = 10;
+  const PROVIDER_POOL_SIZE = 5;
   const PROVIDER_NULL = 0;
   const PROVIDER_REGISTERED = 1;
-
 
   async function approveBondProvider(pricePerStorageMineral, pricePerComputeMineral, blockRewardCut, feeShare, amountBonded, providerAddress) {
       await providerRound.approve(contractAddress, amountBonded, {from: providerAddress});
@@ -109,7 +108,6 @@ contract('ProviderRound', accounts => {
       });
     });
 
-    // TODO add limitation
     // TODO: Doc about providers, pool and active pool
     it('should add the provider to the pool if he is Unregistered and size < maxSize', async () => {
       // Check that provider isn't registered yet
@@ -125,7 +123,8 @@ contract('ProviderRound', accounts => {
     });
 
     it('should fail if provider is Unregistered and size == maxSize', async () => {
-
+      await approveBondProvider(20 ,10, 2, 25, 1, accounts[4]);
+      await assertFail( approveBondProvider(20 ,10, 2, 25, 1, accounts[5]) );
     });
 
     it('should update the value of totalBondedAmount in the providerPool if the provider is Registered and size < maxSize', async () => {
@@ -140,7 +139,7 @@ contract('ProviderRound', accounts => {
     });
 
     it('should work if provider is Registered and size == maxSize', async () => {
-
+      await providerRound.provider(21 ,10, 2, 25, {from: accounts[4]});
     });
   });
 

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -111,7 +111,7 @@ contract('ProviderRound', accounts => {
 
     // TODO add limitation
     // TODO: Doc about providers, pool and active pool
-    it('should add the provider to the pool if he is new and size < maxSize', async () => {
+    it('should add the provider to the pool if he is Unregistered and size < maxSize', async () => {
       // Check that provider isn't registered yet
       assert.equal(false, await providerRound.containsProvider(accounts[3]));
       // Check the size of the pool increases by 1
@@ -124,6 +124,24 @@ contract('ProviderRound', accounts => {
       assert.equal(true, await providerRound.containsProvider(accounts[3]));
     });
 
+    it('should fail if provider is Unregistered and size == maxSize', async () => {
+
+    });
+
+    it('should update the value of totalBondedAmount in the providerPool if the provider is Registered and size < maxSize', async () => {
+      // Check that provider is Registered
+      assert.equal(true, await providerRound.containsProvider(accounts[3]));
+      // Check the size of the pool stays the same
+      let providerPool = await providerRound.providerPool.call();
+      const previousSize = providerPool[3].toNumber(); // [3] is current size of the pool
+      await providerRound.provider(19, 10, 2, 20, {from: accounts[3]});
+      providerPool = await providerRound.providerPool.call();
+      assert.equal(previousSize, providerPool[3]);
+    });
+
+    it('should work if provider is Registered and size == maxSize', async () => {
+
+    });
   });
 
   describe('resignAsProvider', () => {

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -113,10 +113,7 @@ contract('ProviderRound', accounts => {
     // TODO: Doc about providers, pool and active pool
     it('should add the provider to the pool if he is new and size < maxSize', async () => {
       // Check that provider isn't registered yet
-      let provider = await providerRound.getProvider(accounts[3]);
-      // If totalBondedAmount is 0, the provider isn't in the pool
-      // because a provider is required to bond some tokens to himself
-      assert.equal(0, provider[0]) // [0] is key (ie totalBondedAmount)
+      assert.equal(false, await providerRound.containsProvider(accounts[3]));
       // Check the size of the pool increases by 1
       let providerPool = await providerRound.providerPool.call();
       const previousSize = providerPool[3].toNumber(); // [3] is current size of the pool
@@ -124,8 +121,7 @@ contract('ProviderRound', accounts => {
       providerPool = await providerRound.providerPool.call();
       assert.equal(previousSize + 1, providerPool[3]);
       // Check that the provider is registered in the pool now
-      provider = await providerRound.getProvider(accounts[3]);
-      assert.equal(1, provider[0]) // [0] is key (ie totalBondedAmount)
+      assert.equal(true, await providerRound.containsProvider(accounts[3]));
     });
 
   });

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -131,13 +131,13 @@ contract('ProviderRound', accounts => {
 
     it('should fail if provider is Unregistered and size == maxSize', async () => {
       let providerPool = await providerRound.providerPool.call();
-      const maxSize = providerPool[2]; // [2] is maxSize
+      const maxSize = providerPool[2].toNumber(); // [2] is maxSize
       let currentSize = providerPool[3]; // [3] is current size
       assert.isAbove(maxSize, currentSize);
       await approveBondProvider(20 ,10, 2, 25, 1, accounts[4]);
       providerPool = await providerRound.providerPool.call();
       currentSize = providerPool[3];
-      assert.deepEqual(maxSize, currentSize);
+      assert.equal(maxSize, currentSize);
       await assertFail( approveBondProvider(20 ,10, 2, 25, 1, accounts[5]) );
     });
 

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -131,13 +131,13 @@ contract('ProviderRound', accounts => {
 
     it('should fail if provider is Unregistered and size == maxSize', async () => {
       let providerPool = await providerRound.providerPool.call();
-      const maxSize = providerPool[2]; // [2] is maxSize
+      const maxSize = providerPool[2].toNumber(); // [2] is maxSize
       let currentSize = providerPool[3]; // [3] is current size
       assert.isAbove(maxSize, currentSize.toNumber());
       await approveBondProvider(20 ,10, 2, 25, 1, accounts[4]);
       providerPool = await providerRound.providerPool.call();
       currentSize = providerPool[3];
-      assert.deepEqual(maxSize, currentSize);
+      assert.equal(maxSize, currentSize);
       await assertFail( approveBondProvider(20 ,10, 2, 25, 1, accounts[5]) );
     });
 

--- a/test/TestProviderRound.spec.js
+++ b/test/TestProviderRound.spec.js
@@ -37,7 +37,7 @@ contract('ProviderRound', accounts => {
       await assertFail( providerRound.provider(22, 10, 1, 25, {from: accounts[0]}) );
     });
 
-    it('should set totalBondedAmount to the amount bonded', async () => {
+    it('should initially set totalBondedAmount to the amount the provider bonded to himself', async () => {
       await approveBondProvider(22, 10, 1, 25, 42, accounts[0]);
       const provider = await providerRound.providers.call(accounts[0]);
       assert.equal(42, provider[5]); // [5] is totalBondedAmount
@@ -107,6 +107,25 @@ contract('ProviderRound', accounts => {
           _feeShare: 24,
         }
       });
+    });
+
+    // TODO add limitation
+    // TODO: Doc about providers, pool and active pool
+    it('should add the provider to the pool if he is new and size < maxSize', async () => {
+      // Check that provider isn't registered yet
+      let provider = await providerRound.getProvider(accounts[3]);
+      // If totalBondedAmount is 0, the provider isn't in the pool
+      // because a provider is required to bond some tokens to himself
+      assert.equal(0, provider[0]) // [0] is key (ie totalBondedAmount)
+      // Check the size of the pool increases by 1
+      let providerPool = await providerRound.providerPool.call();
+      const previousSize = providerPool[3].toNumber(); // [3] is current size of the pool
+      await approveBondProvider(21, 13, 3, 26, 1, accounts[3]);
+      providerPool = await providerRound.providerPool.call();
+      assert.equal(previousSize + 1, providerPool[3]);
+      // Check that the provider is registered in the pool now
+      provider = await providerRound.getProvider(accounts[3]);
+      assert.equal(1, provider[0]) // [0] is key (ie totalBondedAmount)
     });
 
   });


### PR DESCRIPTION
https://transmute.atlassian.net/browse/ENG-445
https://transmute.atlassian.net/browse/ENG-446

Changes:
- Providers have to bond() to themselves before calling provider()
- Add more functions to interact with providerPool
- `provider()` now adds and updates providers in the providerPool
- Some updates in the tests

More documentation coming soon 