### PR TITLE
Feat/eng 483 create jobs

### DIFF
--- a/contracts/JobManager.sol
+++ b/contracts/JobManager.sol
@@ -41,6 +41,8 @@ contract JobManager {
   mapping(uint => Job) public jobs;
 
   function submitMineral(string _name, uint _category) external {
+    // name should be non null
+    require(bytes(_name).length > 0);
     // Mineral has to be one of two categories: Compute or Storage
     MineralCategory mc;
     if(_category == uint(MineralCategory.Compute)) {

--- a/contracts/JobManager.sol
+++ b/contracts/JobManager.sol
@@ -38,7 +38,6 @@ contract JobManager {
   mapping(uint => Job) public jobs;
 
   function submitMineral(string _name, uint _category) external {
-    // TODO name must be non null
     // Mineral has to be one of two categories: Compute or Storage
     MineralCategory mc;
     if(_category == uint(MineralCategory.Compute)) {

--- a/contracts/JobManager.sol
+++ b/contracts/JobManager.sol
@@ -10,16 +10,51 @@ contract JobManager {
     string name
   );
 
+  event JobAdded (
+    uint id,
+    uint mineralId,
+    uint minPricePerMineral,
+    uint expirationBlock
+  );
+
   struct Mineral {
     string name;
+  }
+
+  struct Job {
+    uint mineralId;
+    uint minPricePerMineral;
+    uint expirationBlock;
   }
 
   uint public numberOfMinerals;
   mapping(uint => Mineral) public minerals;
 
+  uint public numberOfJobs;
+  mapping(uint => Job) public jobs;
+
   function submitMineral(string _name) external {
     minerals[numberOfMinerals] = Mineral(_name);
     emit MineralAdded(numberOfMinerals, _name);
     numberOfMinerals = numberOfMinerals.add(1);
+  }
+
+  function mineralIsValid(uint _mineralId) public view returns (bool) {
+    Mineral memory m = minerals[_mineralId];
+    return bytes(m.name).length > 0;
+  }
+
+  function job(uint _mineralId, uint _minPricePerMineral, uint _expirationBlock) external {
+    // mineralId must correspond to an existing mineral
+    require(mineralIsValid(_mineralId));
+    // expirationBlock must be in the future
+    require(_expirationBlock > block.number);
+
+    Job storage j = jobs[numberOfJobs];
+    j.mineralId = _mineralId;
+    j.minPricePerMineral = _minPricePerMineral;
+    j.expirationBlock = _expirationBlock;
+    emit JobAdded(numberOfJobs, _mineralId, _minPricePerMineral, _expirationBlock);
+    numberOfJobs = numberOfJobs.add(1);
   }
 }

--- a/contracts/JobManager.sol
+++ b/contracts/JobManager.sol
@@ -5,7 +5,7 @@ import "zeppelin-solidity/contracts/math/SafeMath.sol";
 contract JobManager {
   using SafeMath for uint;
 
-  enum MineralCategory { Null, Compute, Storage }
+  enum MineralCategory { Compute, Storage }
 
   event MineralAdded (
     uint id,

--- a/contracts/JobManager.sol
+++ b/contracts/JobManager.sol
@@ -57,7 +57,7 @@ contract JobManager {
     return m.category != MineralCategory.Null;
   }
 
-  function job(uint _mineralId, uint _minPricePerMineral, uint _expirationBlock) external {
+  function submitJob(uint _mineralId, uint _minPricePerMineral, uint _expirationBlock) external {
     // mineralId must correspond to an existing mineral
     require(mineralIsValid(_mineralId));
     // expirationBlock must be in the future

--- a/contracts/JobManager.sol
+++ b/contracts/JobManager.sol
@@ -10,6 +10,7 @@ contract JobManager {
   event MineralAdded (
     uint id,
     string name,
+    address producer,
     MineralCategory category
   );
 
@@ -22,12 +23,14 @@ contract JobManager {
 
   struct Mineral {
     string name;
+    address producer;
     MineralCategory category;
   }
 
   struct Job {
     uint mineralId;
     uint minPricePerMineral;
+    // TODO: Add consumer address
     uint expirationBlock;
   }
 
@@ -47,14 +50,14 @@ contract JobManager {
     } else {
       revert();
     }
-    minerals[numberOfMinerals] = Mineral(_name, mc);
-    emit MineralAdded(numberOfMinerals, _name, mc);
+    minerals[numberOfMinerals] = Mineral(_name, msg.sender, mc);
+    emit MineralAdded(numberOfMinerals, _name, msg.sender, mc);
     numberOfMinerals = numberOfMinerals.add(1);
   }
 
   function mineralIsValid(uint _mineralId) public view returns (bool) {
     Mineral memory m = minerals[_mineralId];
-    return m.category != MineralCategory.Null;
+    return m.producer != address(0);
   }
 
   function submitJob(uint _mineralId, uint _minPricePerMineral, uint _expirationBlock) external {

--- a/contracts/JobManager.sol
+++ b/contracts/JobManager.sol
@@ -55,7 +55,7 @@ contract JobManager {
 
   function mineralIsValid(uint _mineralId) public view returns (bool) {
     Mineral memory m = minerals[_mineralId];
-    return bytes(m.name).length > 0;
+    return m.category != MineralCategory.Null;
   }
 
   function job(uint _mineralId, uint _minPricePerMineral, uint _expirationBlock) external {

--- a/contracts/JobManager.sol
+++ b/contracts/JobManager.sol
@@ -5,9 +5,12 @@ import "zeppelin-solidity/contracts/math/SafeMath.sol";
 contract JobManager {
   using SafeMath for uint;
 
+  enum MineralCategory { Null, Compute, Storage }
+
   event MineralAdded (
     uint id,
-    string name
+    string name,
+    MineralCategory category
   );
 
   event JobAdded (
@@ -19,6 +22,7 @@ contract JobManager {
 
   struct Mineral {
     string name;
+    MineralCategory category;
   }
 
   struct Job {
@@ -33,9 +37,19 @@ contract JobManager {
   uint public numberOfJobs;
   mapping(uint => Job) public jobs;
 
-  function submitMineral(string _name) external {
-    minerals[numberOfMinerals] = Mineral(_name);
-    emit MineralAdded(numberOfMinerals, _name);
+  function submitMineral(string _name, uint _category) external {
+    // TODO name must be non null
+    // Mineral has to be one of two categories: Compute or Storage
+    MineralCategory mc;
+    if(_category == uint(MineralCategory.Compute)) {
+      mc = MineralCategory.Compute;
+    } else if (_category == uint(MineralCategory.Storage)) {
+      mc = MineralCategory.Storage;
+    } else {
+      revert();
+    }
+    minerals[numberOfMinerals] = Mineral(_name, mc);
+    emit MineralAdded(numberOfMinerals, _name, mc);
     numberOfMinerals = numberOfMinerals.add(1);
   }
 

--- a/contracts/TransmuteDPOS.sol
+++ b/contracts/TransmuteDPOS.sol
@@ -99,7 +99,7 @@ contract TransmuteDPOS is TransmuteToken, RoundManager, ProviderPool {
   }
 
   function resignAsProvider(address _provider) internal {
-    require(providerStatus(_provider) != ProviderStatus.Unregistered);
+    require(providerStatus(_provider) == ProviderStatus.Registered);
     removeProvider(_provider);
     delete providers[_provider];
     emit ProviderResigned(_provider);

--- a/contracts/TransmuteDPOS.sol
+++ b/contracts/TransmuteDPOS.sol
@@ -52,7 +52,6 @@ contract TransmuteDPOS is TransmuteToken, RoundManager, ProviderPool {
   enum ProviderStatus { Unregistered, Registered }
 
   struct Provider {
-    ProviderStatus status;
     uint pricePerStorageMineral;
     uint pricePerComputeMineral;
     uint blockRewardCut;
@@ -86,14 +85,13 @@ contract TransmuteDPOS is TransmuteToken, RoundManager, ProviderPool {
     Delegator storage d = delegators[msg.sender];
     // Provider has to be a Delegator to himself
     require(d.delegateAddress == msg.sender);
-    if (p.status == ProviderStatus.Unregistered) {
+    if (providerStatus(msg.sender) == ProviderStatus.Unregistered) {
       numberOfProviders = numberOfProviders.add(1);
       addProvider(msg.sender, p.totalAmountBonded);
       emit ProviderAdded(msg.sender, _pricePerStorageMineral, _pricePerComputeMineral, _blockRewardCut, _feeShare);
     } else {
       emit ProviderUpdated(msg.sender, _pricePerStorageMineral, _pricePerComputeMineral, _blockRewardCut, _feeShare);
     }
-    p.status = ProviderStatus.Registered;
     p.pricePerStorageMineral = _pricePerStorageMineral;
     p.pricePerComputeMineral = _pricePerComputeMineral;
     p.blockRewardCut = _blockRewardCut;
@@ -101,7 +99,7 @@ contract TransmuteDPOS is TransmuteToken, RoundManager, ProviderPool {
   }
 
   function resignAsProvider(address _provider) internal {
-    require(providers[_provider].status != ProviderStatus.Unregistered);
+    require(providerStatus(_provider) != ProviderStatus.Unregistered);
     removeProvider(_provider);
     delete providers[_provider];
     emit ProviderResigned(_provider);
@@ -112,14 +110,15 @@ contract TransmuteDPOS is TransmuteToken, RoundManager, ProviderPool {
     Provider storage p = providers[_provider];
     // A delegator is only allowed to bond to himself (in which case he wants to be a Provider)
     // or to a Registered Provider
-    require(_provider == msg.sender || p.status == ProviderStatus.Registered);
+    ProviderStatus pStatus = providerStatus(_provider);
+    require(_provider == msg.sender || pStatus == ProviderStatus.Registered);
     // Check if delegator has not already bonded to some address
     require(delegators[msg.sender].delegateAddress == address(0));
     this.transferFrom(msg.sender, this, _amount);
     delegators[msg.sender] = Delegator(_provider, _amount);
     p.totalAmountBonded = p.totalAmountBonded.add(_amount);
     // Update the bonded amount of the provider in the pool
-    if (p.status == ProviderStatus.Registered) {
+    if (pStatus == ProviderStatus.Registered) {
       updateProvider(_provider, p.totalAmountBonded);
     }
     emit DelegatorBonded(msg.sender, _provider, _amount);
@@ -157,8 +156,14 @@ contract TransmuteDPOS is TransmuteToken, RoundManager, ProviderPool {
     delete withdrawInformations[msg.sender];
   }
 
-  // TODO: Create the same function for Providers
-  // This will remove the need for ProviderStatus inside the Provider Struct
+  function providerStatus(address _provider) public view returns (ProviderStatus) {
+    if (this.containsProvider(_provider)) {
+      return ProviderStatus.Registered;
+    } else {
+      return ProviderStatus.Unregistered;
+    }
+  }
+
   function delegatorStatus(address _delegator) public view returns (DelegatorStatus) {
     if (delegators[_delegator].amountBonded != 0) {
       // If _delegator is in the mapping, he is Bonded

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -48,6 +48,14 @@ contract('JobManager', accounts => {
         }
       });
     });
+
+    it('should accept no name for Mineral', async () => {
+      const mineralId = (await jm.numberOfMinerals.call()).toNumber();
+      await jm.submitMineral("", MINERAL_COMPUTE);
+      const mineral = await jm.minerals.call(mineralId);
+      let [name, _] = mineral;
+      assert.equal("", name);
+    });
   });
 
   describe('job', () => {

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -14,11 +14,20 @@ contract('JobManager', accounts => {
       jm = await JobManager.deployed();
     });
 
+    it('should fail if category is not MINERAL_COMPUTE or MINERAL_STORAGE', async () => {
+      await assertFail( jm.submitMineral("test", 0) );
+      await jm.submitMineral("test", MINERAL_COMPUTE);
+      await jm.submitMineral("test", MINEARL_STORAGE);
+      await assertFail( jm.submitMineral("test", 3) );
+    });
+
     it('should store the Mineral in the minerals mapping', async () => {
+      const mineralId = (await jm.numberOfMinerals.call()).toNumber();
       await jm.submitMineral('multiplication', MINERAL_COMPUTE);
-      const mineral = await jm.minerals.call(0);
+      const mineral = await jm.minerals.call(mineralId);
       let [name, category] = mineral;
       assert.equal('multiplication', name);
+      assert.equal(MINERAL_COMPUTE, category);
     });
 
     it('should increment numberOfMinerals', async () => {
@@ -28,11 +37,12 @@ contract('JobManager', accounts => {
     });
 
     it('should emit a MineralAdded event', async () => {
+      const mineralId = (await jm.numberOfMinerals.call()).toNumber();
       let result = await jm.submitMineral('division', MINERAL_COMPUTE);
       assert.web3Event(result, {
         event: 'MineralAdded',
         args: {
-          id: 2,
+          id: mineralId,
           name: 'division',
           category: MINERAL_COMPUTE,
         }

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -50,12 +50,13 @@ contract('JobManager', accounts => {
       });
     });
 
-    it('should accept no name for Mineral', async () => {
+    it('should fail if name is an empty string', async () => {
       const mineralId = (await jm.numberOfMinerals.call()).toNumber();
-      await jm.submitMineral("", MINERAL_COMPUTE);
+      await assertFail( jm.submitMineral("", MINERAL_COMPUTE) );
+      await jm.submitMineral("non empty string", MINERAL_COMPUTE);
       const mineral = await jm.minerals.call(mineralId);
       let name = mineral[0];
-      assert.equal("", name);
+      assert.equal("non empty string", name);
     });
   });
 

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -53,7 +53,7 @@ contract('JobManager', accounts => {
       const mineralId = (await jm.numberOfMinerals.call()).toNumber();
       await jm.submitMineral("", MINERAL_COMPUTE);
       const mineral = await jm.minerals.call(mineralId);
-      let [name, _] = mineral;
+      let name = mineral[0];
       assert.equal("", name);
     });
   });

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -5,8 +5,8 @@ require('truffle-test-utils').init();
 contract('JobManager', accounts => {
 
   let jm;
-  const MINERAL_COMPUTE = 1;
-  const MINERAL_STORAGE = 2;
+  const MINERAL_COMPUTE = 0;
+  const MINERAL_STORAGE = 1;
 
   describe('submitMineral', () => {
 
@@ -15,10 +15,9 @@ contract('JobManager', accounts => {
     });
 
     it('should fail if category is not MINERAL_COMPUTE or MINERAL_STORAGE', async () => {
-      await assertFail( jm.submitMineral("test", 0) );
       await jm.submitMineral("test", MINERAL_COMPUTE);
       await jm.submitMineral("test", MINERAL_STORAGE);
-      await assertFail( jm.submitMineral("test", 3) );
+      await assertFail( jm.submitMineral("test", 2) );
     });
 
     it('should store the Mineral in the minerals mapping', async () => {

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -18,7 +18,7 @@ contract('JobManager', accounts => {
       assert.equal('multiplication', mineral);
     });
 
-    it('should increase the value of numberOfMinerals', async () => {
+    it('should increment numberOfMinerals', async () => {
       const numberOfMinerals = await jm.numberOfMinerals.call();
       await jm.submitMineral('addition');
       assert.deepEqual(numberOfMinerals.add(1), await jm.numberOfMinerals.call())

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -58,7 +58,7 @@ contract('JobManager', accounts => {
     });
   });
 
-  describe('job', () => {
+  describe('submitJob', () => {
 
     let expirationBlock = web3.eth.blockNumber + 1000;
 
@@ -69,22 +69,22 @@ contract('JobManager', accounts => {
     });
 
     it('should fail if mineralId is not the id of a valid Mineral', async () => {
-      await assertFail( jm.job(2, 10, expirationBlock) );
-      await jm.job(0, 10, expirationBlock);
+      await assertFail( jm.submitJob(2, 10, expirationBlock) );
+      await jm.submitJob(0, 10, expirationBlock);
     });
 
     it('should fail if expiration block is not in the future', async () => {
       const blockInThePast = web3.eth.blockNumber;
-      await assertFail( jm.job(0, 10, blockInThePast) );
+      await assertFail( jm.submitJob(0, 10, blockInThePast) );
       const presentBlock = web3.eth.blockNumber + 1;
-      await assertFail( jm.job(0, 10, presentBlock) );
+      await assertFail( jm.submitJob(0, 10, presentBlock) );
       const blockInTheFuture = web3.eth.blockNumber + 2;
-      await jm.job(0, 10, blockInTheFuture);
+      await jm.submitJob(0, 10, blockInTheFuture);
     });
 
     it('should store the Job parameters in the jobs mapping', async () => {
       const jobId = await jm.numberOfJobs.call();
-      await jm.job(1, 11, expirationBlock + 42);
+      await jm.submitJob(1, 11, expirationBlock + 42);
       const job = await jm.jobs.call(jobId);
       const [mineralId, minPricePerMineral, expBlock] = job;
       assert.equal(1, mineralId);
@@ -94,7 +94,7 @@ contract('JobManager', accounts => {
 
     it('should emit a JobAdded event', async () => {
       const jobId = await jm.numberOfJobs.call();
-      let result = await jm.job(1, 12, expirationBlock);
+      let result = await jm.submitJob(1, 12, expirationBlock);
       assert.web3Event(result, {
         event: 'JobAdded',
         args: {
@@ -108,7 +108,7 @@ contract('JobManager', accounts => {
 
     it('should increment numberOfJobs', async () => {
       const numberOfJobs = await jm.numberOfJobs.call();
-      await jm.job(1, 12, expirationBlock);
+      await jm.submitJob(1, 12, expirationBlock);
       assert.deepEqual(numberOfJobs.add(1), await jm.numberOfJobs.call())
     });
   });

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -23,10 +23,11 @@ contract('JobManager', accounts => {
 
     it('should store the Mineral in the minerals mapping', async () => {
       const mineralId = (await jm.numberOfMinerals.call()).toNumber();
-      await jm.submitMineral('multiplication', MINERAL_COMPUTE);
+      await jm.submitMineral('multiplication', MINERAL_COMPUTE, {from: accounts[0]});
       const mineral = await jm.minerals.call(mineralId);
-      let [name, category] = mineral;
+      let [name, producer, category] = mineral;
       assert.equal('multiplication', name);
+      assert.equal(accounts[0], producer);
       assert.equal(MINERAL_COMPUTE, category);
     });
 
@@ -38,12 +39,13 @@ contract('JobManager', accounts => {
 
     it('should emit a MineralAdded event', async () => {
       const mineralId = (await jm.numberOfMinerals.call()).toNumber();
-      let result = await jm.submitMineral('division', MINERAL_COMPUTE);
+      let result = await jm.submitMineral('division', MINERAL_COMPUTE, {from: accounts[0]});
       assert.web3Event(result, {
         event: 'MineralAdded',
         args: {
           id: mineralId,
           name: 'division',
+          producer: accounts[0],
           category: MINERAL_COMPUTE,
         }
       });

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -5,6 +5,8 @@ require('truffle-test-utils').init();
 contract('JobManager', accounts => {
 
   let jm;
+  const MINERAL_COMPUTE = 1;
+  const MINEARL_STORAGE = 2;
 
   describe('submitMineral', () => {
 
@@ -13,24 +15,26 @@ contract('JobManager', accounts => {
     });
 
     it('should store the Mineral in the minerals mapping', async () => {
-      await jm.submitMineral('multiplication');
+      await jm.submitMineral('multiplication', MINERAL_COMPUTE);
       const mineral = await jm.minerals.call(0);
-      assert.equal('multiplication', mineral);
+      let [name, category] = mineral;
+      assert.equal('multiplication', name);
     });
 
     it('should increment numberOfMinerals', async () => {
       const numberOfMinerals = await jm.numberOfMinerals.call();
-      await jm.submitMineral('addition');
+      await jm.submitMineral('addition', MINERAL_COMPUTE);
       assert.deepEqual(numberOfMinerals.add(1), await jm.numberOfMinerals.call())
     });
 
     it('should emit a MineralAdded event', async () => {
-      let result = await jm.submitMineral('division');
+      let result = await jm.submitMineral('division', MINERAL_COMPUTE);
       assert.web3Event(result, {
         event: 'MineralAdded',
         args: {
           id: 2,
           name: 'division',
+          category: MINERAL_COMPUTE,
         }
       });
     });
@@ -42,8 +46,8 @@ contract('JobManager', accounts => {
 
     before(async () => {
       jm = await JobManager.new();
-      await jm.submitMineral("multiplication");
-      await jm.submitMineral("addition");
+      await jm.submitMineral("multiplication", MINERAL_COMPUTE);
+      await jm.submitMineral("addition", MINERAL_COMPUTE);
     });
 
     it('should fail if mineralId is not the id of a valid Mineral', async () => {

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -1,4 +1,5 @@
 const JobManager = artifacts.require('./JobManager.sol');
+const { assertFail } = require('./utils.js');
 require('truffle-test-utils').init();
 
 contract('JobManager', accounts => {
@@ -32,6 +33,61 @@ contract('JobManager', accounts => {
           name: 'division',
         }
       });
+    });
+  });
+
+  describe('job', () => {
+
+    let expirationBlock = web3.eth.blockNumber + 1000;
+
+    before(async () => {
+      jm = await JobManager.new();
+      await jm.submitMineral("multiplication");
+      await jm.submitMineral("addition");
+    });
+
+    it('should fail if mineralId is not the id of a valid Mineral', async () => {
+      await assertFail( jm.job(2, 10, expirationBlock) );
+      await jm.job(0, 10, expirationBlock);
+    });
+
+    it('should fail if expiration block is not in the future', async () => {
+      const blockInThePast = web3.eth.blockNumber;
+      await assertFail( jm.job(0, 10, blockInThePast) );
+      const presentBlock = web3.eth.blockNumber + 1;
+      await assertFail( jm.job(0, 10, presentBlock) );
+      const blockInTheFuture = web3.eth.blockNumber + 2;
+      await jm.job(0, 10, blockInTheFuture);
+    });
+
+    it('should store the Job parameters in the jobs mapping', async () => {
+      const jobId = await jm.numberOfJobs.call();
+      await jm.job(1, 11, expirationBlock + 42);
+      const job = await jm.jobs.call(jobId);
+      const [mineralId, minPricePerMineral, expBlock] = job;
+      assert.equal(1, mineralId);
+      assert.equal(11, minPricePerMineral);
+      assert.equal(expirationBlock + 42, expBlock);
+    });
+
+    it('should emit a JobAdded event', async () => {
+      const jobId = await jm.numberOfJobs.call();
+      let result = await jm.job(1, 12, expirationBlock);
+      assert.web3Event(result, {
+        event: 'JobAdded',
+        args: {
+          id: jobId.toNumber(),
+          mineralId: 1,
+          minPricePerMineral: 12,
+          expirationBlock: expirationBlock
+        }
+      });
+    });
+
+    it('should increment numberOfJobs', async () => {
+      const numberOfJobs = await jm.numberOfJobs.call();
+      await jm.job(1, 12, expirationBlock);
+      assert.deepEqual(numberOfJobs.add(1), await jm.numberOfJobs.call())
     });
   });
 });

--- a/test/JobManager.spec.js
+++ b/test/JobManager.spec.js
@@ -6,7 +6,7 @@ contract('JobManager', accounts => {
 
   let jm;
   const MINERAL_COMPUTE = 1;
-  const MINEARL_STORAGE = 2;
+  const MINERAL_STORAGE = 2;
 
   describe('submitMineral', () => {
 
@@ -17,7 +17,7 @@ contract('JobManager', accounts => {
     it('should fail if category is not MINERAL_COMPUTE or MINERAL_STORAGE', async () => {
       await assertFail( jm.submitMineral("test", 0) );
       await jm.submitMineral("test", MINERAL_COMPUTE);
-      await jm.submitMineral("test", MINEARL_STORAGE);
+      await jm.submitMineral("test", MINERAL_STORAGE);
       await assertFail( jm.submitMineral("test", 3) );
     });
 


### PR DESCRIPTION
https://transmute.atlassian.net/browse/ENG-483

- Job manager
    - Added category to Mineral struct (either Compute or Storage)
    - Added submitJob function
- DPOS
    - Provider.status was redundant with the `containsProvider()` function. Removed Provider.status and replaced it with `providerStatus` that uses `containsProvider` to determine if Provider is `Registered` or `Unregistered`