### PR TITLE
Feat/eng 486 active providers set

### DIFF
--- a/contracts/DelegatorManager.sol
+++ b/contracts/DelegatorManager.sol
@@ -17,7 +17,6 @@ contract DelegatorManager {
 
   struct Delegator {
     address delegateAddress;
-    // TODO: rename variable
     uint amountBonded;
   }
 

--- a/contracts/DelegatorManager.sol
+++ b/contracts/DelegatorManager.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.4.24;
+
+contract DelegatorManager {
+  event DelegatorBonded(
+    address indexed _delegator,
+    address indexed _provider,
+    uint _amount
+  );
+
+  event DelegatorUnbonded(
+    address indexed _delegator,
+    address indexed _provider,
+    uint _amount
+  );
+
+  enum DelegatorStatus { Unbonded, UnbondedWithTokensToWithdraw, Bonded }
+
+  struct Delegator {
+    address delegateAddress;
+    // TODO: rename variable
+    uint amountBonded;
+  }
+
+  uint public numberOfDelegators;
+  mapping(address => Delegator) public delegators;
+
+  struct WithdrawInformation {
+    uint withdrawBlock;
+    uint amount;
+  }
+
+  mapping (address => WithdrawInformation) public withdrawInformations;
+}

--- a/contracts/DelegatorManager.sol
+++ b/contracts/DelegatorManager.sol
@@ -2,15 +2,15 @@ pragma solidity ^0.4.24;
 
 contract DelegatorManager {
   event DelegatorBonded(
-    address indexed _delegator,
-    address indexed _provider,
-    uint _amount
+    address indexed delegator,
+    address indexed provider,
+    uint amount
   );
 
   event DelegatorUnbonded(
-    address indexed _delegator,
-    address indexed _provider,
-    uint _amount
+    address indexed delegator,
+    address indexed provider,
+    uint amount
   );
 
   enum DelegatorStatus { Unbonded, UnbondedWithTokensToWithdraw, Bonded }

--- a/contracts/ProviderManager.sol
+++ b/contracts/ProviderManager.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.24;
 
 contract ProviderManager {
+  //TODO: remove _
   event ProviderAdded (
     address indexed _provider,
     uint _pricePerStorageMineral,
@@ -28,7 +29,6 @@ contract ProviderManager {
     uint pricePerComputeMineral;
     uint blockRewardCut;
     uint feeShare;
-    uint totalAmountBonded;
   }
 
   uint public numberOfProviders;

--- a/contracts/ProviderManager.sol
+++ b/contracts/ProviderManager.sol
@@ -1,25 +1,24 @@
 pragma solidity ^0.4.24;
 
 contract ProviderManager {
-  //TODO: remove _
   event ProviderAdded (
-    address indexed _provider,
-    uint _pricePerStorageMineral,
-    uint _pricePerComputeMineral,
-    uint _blockRewardCut,
-    uint _feeShare
+    address indexed provider,
+    uint pricePerStorageMineral,
+    uint pricePerComputeMineral,
+    uint blockRewardCut,
+    uint feeShare
   );
 
   event ProviderUpdated (
-    address indexed _provider,
-    uint _pricePerStorageMineral,
-    uint _pricePerComputeMineral,
-    uint _blockRewardCut,
-    uint _feeShare
+    address indexed provider,
+    uint pricePerStorageMineral,
+    uint pricePerComputeMineral,
+    uint blockRewardCut,
+    uint feeShare
   );
 
   event ProviderResigned (
-    address indexed _provider
+    address indexed provider
   );
 
   enum ProviderStatus { Unregistered, Registered }

--- a/contracts/ProviderManager.sol
+++ b/contracts/ProviderManager.sol
@@ -1,0 +1,36 @@
+pragma solidity ^0.4.24;
+
+contract ProviderManager {
+  event ProviderAdded (
+    address indexed _provider,
+    uint _pricePerStorageMineral,
+    uint _pricePerComputeMineral,
+    uint _blockRewardCut,
+    uint _feeShare
+  );
+
+  event ProviderUpdated (
+    address indexed _provider,
+    uint _pricePerStorageMineral,
+    uint _pricePerComputeMineral,
+    uint _blockRewardCut,
+    uint _feeShare
+  );
+
+  event ProviderResigned (
+    address indexed _provider
+  );
+
+  enum ProviderStatus { Unregistered, Registered }
+
+  struct Provider {
+    uint pricePerStorageMineral;
+    uint pricePerComputeMineral;
+    uint blockRewardCut;
+    uint feeShare;
+    uint totalAmountBonded;
+  }
+
+  uint public numberOfProviders;
+  mapping(address => Provider) public providers;
+}

--- a/contracts/ProviderManager.sol
+++ b/contracts/ProviderManager.sol
@@ -32,5 +32,11 @@ contract ProviderManager {
   }
 
   uint public numberOfProviders;
+  // TODO: rename to registeredProviders
   mapping(address => Provider) public providers;
+
+  // Saves the parameters of active providers for that round.
+  // Any updates via provider() will save the parameters in providers mapping
+  // and will be copied to this mapping at the next call of initializeRound()
+  mapping(address => Provider) public activeProviders;
 }

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -11,7 +11,7 @@ contract ProviderPool is Ownable {
   using SortedDoublyLL for SortedDoublyLL.Data;
   SortedDoublyLL.Data public providerPool;
 
-  function setMaxNumberOfProviders(uint _maxNumber) external onlyOwner {
+  function setProviderPoolMaxSize(uint _maxNumber) external onlyOwner {
     // TODO: providerPool.maxSize = _maxNumber;
     providerPool.setMaxSize(_maxNumber);
   }

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -9,8 +9,7 @@ contract ProviderPool is Ownable {
   uint public numberOfActiveProviders;
 
   using SortedDoublyLL for SortedDoublyLL.Data;
-  // TODO: Change visibility ?
-  SortedDoublyLL.Data public providerPool;
+  SortedDoublyLL.Data internal providerPool;
 
   function setProviderPoolMaxSize(uint _maxNumber) external onlyOwner {
     // TODO: Remove limitation providerPool.maxSize = _maxNumber;
@@ -49,6 +48,10 @@ contract ProviderPool is Ownable {
     return providerPool.getFirst();
   }
 
+  function getLastProvider() public view returns (address) {
+    return providerPool.getLast();
+  }
+
   function getNextProvider(address _provider) public view returns (address) {
     return providerPool.getNext(_provider);
   }
@@ -59,6 +62,10 @@ contract ProviderPool is Ownable {
 
   function getProviderPoolSize() public view returns (uint) {
     return providerPool.size;
+  }
+
+  function getProviderPoolMaxSize() public view returns (uint) {
+    return providerPool.maxSize;
   }
 
 }

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -4,8 +4,22 @@ import "./SortedDoublyLL.sol";
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract ProviderPool is Ownable {
+
+  // TODO: init
+  uint public numberOfActiveProviders;
+
   using SortedDoublyLL for SortedDoublyLL.Data;
   SortedDoublyLL.Data public providerPool;
+
+  function setMaxNumberOfProviders(uint _maxNumber) external onlyOwner {
+    // TODO: providerPool.maxSize = _maxNumber;
+    providerPool.setMaxSize(_maxNumber);
+  }
+
+  function setNumberOfActiveProviders(uint _numberOfActiveProviders) external onlyOwner {
+    require(_numberOfActiveProviders <= providerPool.maxSize);
+    numberOfActiveProviders = _numberOfActiveProviders;
+  }
 
   // @dev convenience method to access the 'nodes' mapping that lives inside providerPool
   function getProvider(address _provider) external view returns (uint, address, address) {
@@ -15,10 +29,6 @@ contract ProviderPool is Ownable {
 
   function containsProvider(address _provider) external view returns (bool) {
     return providerPool.contains(_provider);
-  }
-
-  function setMaxNumberOfProviders(uint _maxNumber) external onlyOwner {
-    providerPool.setMaxSize(_maxNumber);
   }
 
   function addProvider(address _provider, uint _bondedAmount) internal {

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -32,11 +32,6 @@ contract ProviderPool is Ownable {
     return providerPool.contains(_provider);
   }
 
-  // TODO
-  function getProviderStake(address _provider) public view returns (uint) {
-    return providerPool.nodes[_provider].key;
-  }
-
   function addProvider(address _provider, uint _bondedAmount) internal {
     providerPool.insert(_provider, _bondedAmount, 0, 0);
   }
@@ -48,4 +43,22 @@ contract ProviderPool is Ownable {
   function removeProvider(address _provider) internal {
     providerPool.remove(_provider);
   }
+
+  // Getter functions for providerPool
+  function getFirstProvider() public view returns (address) {
+    return providerPool.getFirst();
+  }
+
+  function getNextProvider(address _provider) public view returns (address) {
+    return providerPool.getNext(_provider);
+  }
+
+  function getProviderStake(address _provider) public view returns (uint) {
+    return providerPool.nodes[_provider].key;
+  }
+
+  function getProviderPoolSize() public view returns (uint) {
+    return providerPool.size;
+  }
+
 }

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -12,11 +12,10 @@ contract ProviderPool is Ownable {
   SortedDoublyLL.Data public providerPool;
 
   function setProviderPoolMaxSize(uint _maxNumber) external onlyOwner {
-    // TODO: providerPool.maxSize = _maxNumber;
+    // TODO: Remove limitation providerPool.maxSize = _maxNumber;
     providerPool.setMaxSize(_maxNumber);
   }
 
-  // TODO: tests
   function setNumberOfActiveProviders(uint _numberOfActiveProviders) external onlyOwner {
     require(_numberOfActiveProviders <= providerPool.maxSize);
     numberOfActiveProviders = _numberOfActiveProviders;

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -16,6 +16,7 @@ contract ProviderPool is Ownable {
     providerPool.setMaxSize(_maxNumber);
   }
 
+  // TODO: tests
   function setNumberOfActiveProviders(uint _numberOfActiveProviders) external onlyOwner {
     require(_numberOfActiveProviders <= providerPool.maxSize);
     numberOfActiveProviders = _numberOfActiveProviders;

--- a/contracts/ProviderPool.sol
+++ b/contracts/ProviderPool.sol
@@ -9,6 +9,7 @@ contract ProviderPool is Ownable {
   uint public numberOfActiveProviders;
 
   using SortedDoublyLL for SortedDoublyLL.Data;
+  // TODO: Change visibility ?
   SortedDoublyLL.Data public providerPool;
 
   function setProviderPoolMaxSize(uint _maxNumber) external onlyOwner {
@@ -29,6 +30,11 @@ contract ProviderPool is Ownable {
 
   function containsProvider(address _provider) external view returns (bool) {
     return providerPool.contains(_provider);
+  }
+
+  // TODO
+  function getProviderStake(address _provider) public view returns (uint) {
+    return providerPool.nodes[_provider].key;
   }
 
   function addProvider(address _provider, uint _bondedAmount) internal {

--- a/contracts/RoundManager.sol
+++ b/contracts/RoundManager.sol
@@ -23,7 +23,7 @@ contract RoundManager is Ownable, ProviderPool, ProviderManager {
   struct ActiveProviderSet {
     address[] providers;
     mapping (address => bool) isActive;
-    uint256 totalStake;
+    uint totalStake;
   }
 
   // Stores the ActiveProviderSet for each round
@@ -54,28 +54,30 @@ contract RoundManager is Ownable, ProviderPool, ProviderManager {
     setActiveProviders();
   }
 
-  // TODO: tests
   function setActiveProviders() internal {
     // Value must have been initialized
     require(numberOfActiveProviders > 0);
 
-    uint totalStake = 0;
-    uint activeSetSize = Math.min256(numberOfActiveProviders, providerPool.size);
-    address currentProvider = providerPool.getFirst();
+    uint activeSetSize = Math.min256(numberOfActiveProviders, getProviderPoolSize());
+    address currentProvider = getFirstProvider();
     ActiveProviderSet storage aps = activeProviderSets[roundNumber];
     for (uint i = 0; i < activeSetSize; i++) {
       aps.providers.push(currentProvider);
       aps.isActive[currentProvider] = true;
 
-      uint stake = providerPool.getKey(currentProvider);
-      totalStake = totalStake.add(stake);
+      uint stake = getProviderStake(currentProvider);
+      aps.totalStake = aps.totalStake.add(stake);
 
       // Set pending rates as current rates
       activeProviders[currentProvider] = providers[currentProvider];
 
       // Get next provider in the pool
-      currentProvider = providerPool.getNext(currentProvider);
+      currentProvider = getNextProvider(currentProvider);
     }
-    aps.totalStake = totalStake;
+  }
+
+  // Getter function for ActiveProviderSet
+  function getActiveProviderAddresses() public returns (address[]) {
+    return activeProviderSets[roundNumber].providers;
   }
 }

--- a/contracts/RoundManager.sol
+++ b/contracts/RoundManager.sol
@@ -2,9 +2,11 @@ pragma solidity ^0.4.24;
 
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "zeppelin-solidity/contracts/math/Math.sol";
 import "./ProviderPool.sol";
+import "./ProviderManager.sol";
 
-contract RoundManager is Ownable, ProviderPool {
+contract RoundManager is Ownable, ProviderPool, ProviderManager {
   using SafeMath for uint;
 
   // Round number of the last round
@@ -16,6 +18,16 @@ contract RoundManager is Ownable, ProviderPool {
   uint public rateLockDeadline;
   // The time (in number of blocks) that a Delegator has to wait before he can withdraw() his tokens
   uint public unbondingPeriod;
+
+  // The set of active Providers for a given round
+  struct ActiveProviderSet {
+    address[] providers;
+    mapping (address => bool) isActive;
+    uint256 totalStake;
+  }
+
+  // Stores the ActiveProviderSet for each round
+  mapping (uint => ActiveProviderSet) public activeProviderSets;
 
   modifier onlyBeforeActiveRoundIsLocked() {
     require(roundNumber > 0);
@@ -39,5 +51,31 @@ contract RoundManager is Ownable, ProviderPool {
     require(block.number.sub(startOfCurrentRound) >= electionPeriodLength);
     roundNumber = roundNumber.add(1);
     startOfCurrentRound = block.number;
+    setActiveProviders();
+  }
+
+  function setActiveProviders() internal {
+    // Value must have been initialized
+    // TODO: require(numberOfActiveProviders > 0);
+
+    uint totalStake = 0;
+    uint activeSetSize = Math.min256(numberOfActiveProviders, providerPool.size);
+    address currentProvider = providerPool.getFirst();
+    ActiveProviderSet storage aps = activeProviderSets[roundNumber];
+    for (uint i = 0; i < activeSetSize; i++) {
+      aps.providers.push(currentProvider);
+      // TODO: Optimization possible by removing this
+      aps.isActive[currentProvider] = true;
+
+      uint stake = providerPool.getKey(currentProvider);
+      totalStake = totalStake.add(stake);
+
+      // Set pending rates as current rates
+      Provider storage p = providers[currentProvider];
+
+      // Get next provider in the pool
+      currentProvider = providerPool.getNext(currentProvider);
+    }
+    aps.totalStake = totalStake;
   }
 }

--- a/contracts/RoundManager.sol
+++ b/contracts/RoundManager.sol
@@ -64,7 +64,6 @@ contract RoundManager is Ownable, ProviderPool, ProviderManager {
     ActiveProviderSet storage aps = activeProviderSets[roundNumber];
     for (uint i = 0; i < activeSetSize; i++) {
       aps.providers.push(currentProvider);
-      // TODO: Optimization possible by removing this
       aps.isActive[currentProvider] = true;
 
       uint stake = providerPool.getKey(currentProvider);

--- a/contracts/RoundManager.sol
+++ b/contracts/RoundManager.sol
@@ -54,6 +54,7 @@ contract RoundManager is Ownable, ProviderPool, ProviderManager {
     setActiveProviders();
   }
 
+  // TODO: tests
   function setActiveProviders() internal {
     // Value must have been initialized
     require(numberOfActiveProviders > 0);
@@ -70,7 +71,7 @@ contract RoundManager is Ownable, ProviderPool, ProviderManager {
       totalStake = totalStake.add(stake);
 
       // Set pending rates as current rates
-      Provider storage p = providers[currentProvider];
+      activeProviders[currentProvider] = providers[currentProvider];
 
       // Get next provider in the pool
       currentProvider = providerPool.getNext(currentProvider);

--- a/contracts/RoundManager.sol
+++ b/contracts/RoundManager.sol
@@ -56,7 +56,7 @@ contract RoundManager is Ownable, ProviderPool, ProviderManager {
 
   function setActiveProviders() internal {
     // Value must have been initialized
-    // TODO: require(numberOfActiveProviders > 0);
+    require(numberOfActiveProviders > 0);
 
     uint totalStake = 0;
     uint activeSetSize = Math.min256(numberOfActiveProviders, providerPool.size);

--- a/contracts/RoundManager.sol
+++ b/contracts/RoundManager.sol
@@ -2,8 +2,9 @@ pragma solidity ^0.4.24;
 
 import "zeppelin-solidity/contracts/math/SafeMath.sol";
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./ProviderPool.sol";
 
-contract RoundManager is Ownable {
+contract RoundManager is Ownable, ProviderPool {
   using SafeMath for uint;
 
   // Round number of the last round

--- a/contracts/TransmuteDPOS.sol
+++ b/contracts/TransmuteDPOS.sol
@@ -2,9 +2,8 @@ pragma solidity ^0.4.24;
 
 import "./TransmuteToken.sol";
 import "./RoundManager.sol";
-import "./ProviderPool.sol";
 
-contract TransmuteDPOS is TransmuteToken, RoundManager, ProviderPool {
+contract TransmuteDPOS is TransmuteToken, RoundManager {
 
   event DelegatorBonded(
     address indexed _delegator,

--- a/contracts/TransmuteDPOS.sol
+++ b/contracts/TransmuteDPOS.sol
@@ -5,68 +5,6 @@ import "./RoundManager.sol";
 
 contract TransmuteDPOS is TransmuteToken, RoundManager {
 
-  event DelegatorBonded(
-    address indexed _delegator,
-    address indexed _provider,
-    uint _amount
-  );
-
-  event DelegatorUnbonded(
-    address indexed _delegator,
-    address indexed _provider,
-    uint _amount
-  );
-
-  event ProviderAdded (
-    address indexed _provider,
-    uint _pricePerStorageMineral,
-    uint _pricePerComputeMineral,
-    uint _blockRewardCut,
-    uint _feeShare
-  );
-
-  event ProviderUpdated (
-    address indexed _provider,
-    uint _pricePerStorageMineral,
-    uint _pricePerComputeMineral,
-    uint _blockRewardCut,
-    uint _feeShare
-  );
-
-  event ProviderResigned (
-    address indexed _provider
-  );
-
-  enum DelegatorStatus { Unbonded, UnbondedWithTokensToWithdraw, Bonded }
-
-  struct Delegator {
-    address delegateAddress;
-    // TODO: rename variable
-    uint amountBonded;
-  }
-
-  uint public numberOfDelegators;
-  mapping(address => Delegator) public delegators;
-
-  enum ProviderStatus { Unregistered, Registered }
-
-  struct Provider {
-    uint pricePerStorageMineral;
-    uint pricePerComputeMineral;
-    uint blockRewardCut;
-    uint feeShare;
-    uint totalAmountBonded;
-  }
-
-  uint public numberOfProviders;
-  mapping(address => Provider) public providers;
-
-  struct WithdrawInformation {
-    uint withdrawBlock;
-    uint amount;
-  }
-  mapping (address => WithdrawInformation) public withdrawInformations;
-
   // FIXME: Those are temporary values
   constructor() public {
     // Set constants from RoundManager

--- a/contracts/TransmuteDPOS.sol
+++ b/contracts/TransmuteDPOS.sol
@@ -2,8 +2,9 @@ pragma solidity ^0.4.24;
 
 import "./TransmuteToken.sol";
 import "./RoundManager.sol";
+import "./DelegatorManager.sol";
 
-contract TransmuteDPOS is TransmuteToken, RoundManager {
+contract TransmuteDPOS is TransmuteToken, RoundManager, DelegatorManager {
 
   // FIXME: Those are temporary values
   constructor() public {

--- a/contracts/TransmuteDPOS.sol
+++ b/contracts/TransmuteDPOS.sol
@@ -95,6 +95,7 @@ contract TransmuteDPOS is TransmuteToken, RoundManager, DelegatorManager {
     delete withdrawInformations[msg.sender];
   }
 
+  // Add Active status
   function providerStatus(address _provider) public view returns (ProviderStatus) {
     if (this.containsProvider(_provider)) {
       return ProviderStatus.Registered;

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -5,13 +5,13 @@ const SortedDoublyLL = artifacts.require('./SortedDoublyLL.sol');
 const TestProviderPool = artifacts.require('./TestProviderPool.sol');
 const JobManager = artifacts.require('./JobManager.sol');
 
-module.exports = deployer => {
+module.exports = (deployer) => {
   deployer.deploy(TST);
   deployer.deploy(SortedDoublyLL);
-  deployer.link(SortedDoublyLL, TestTransmuteDPOS);
-  deployer.deploy(TestTransmuteDPOS);
+  deployer.link(SortedDoublyLL, RoundManager);
   deployer.deploy(RoundManager);
   deployer.link(SortedDoublyLL, TestProviderPool);
   deployer.deploy(TestProviderPool);
+  deployer.deploy(TestTransmuteDPOS);
   deployer.deploy(JobManager);
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -8,10 +8,11 @@ const JobManager = artifacts.require('./JobManager.sol');
 module.exports = (deployer) => {
   deployer.deploy(TST);
   deployer.deploy(SortedDoublyLL);
-  deployer.link(SortedDoublyLL, RoundManager);
-  deployer.deploy(RoundManager);
   deployer.link(SortedDoublyLL, TestProviderPool);
   deployer.deploy(TestProviderPool);
+  deployer.link(SortedDoublyLL, RoundManager);
+  deployer.deploy(RoundManager);
+  deployer.link(SortedDoublyLL, TestTransmuteDPOS);
   deployer.deploy(TestTransmuteDPOS);
   deployer.deploy(JobManager);
 };

--- a/test/integration/DPOS.spec.js
+++ b/test/integration/DPOS.spec.js
@@ -142,9 +142,8 @@ contract('integration/TransmuteDPOS', (accounts) => {
     });
 
     it('provider5 registers as Provider but fails because the providerPool is at maximum capacity', async () => {
-      const providerPool = await tdpos.providerPool.call();
-      let maxSize = providerPool[2];
-      let size = providerPool[3];
+      const maxSize = await tdpos.getProviderPoolMaxSize.call();
+      const size = await tdpos.getProviderPoolSize.call();
       assert.deepEqual(maxSize, size);
       await assertFail( tdpos.provider(...STANDARD_PROVIDER_PARAMETERS, {from: provider5}) );
     });

--- a/test/integration/DPOS.spec.js
+++ b/test/integration/DPOS.spec.js
@@ -32,7 +32,7 @@ contract('integration/TransmuteDPOS', (accounts) => {
     for (let i = 0; i < 10; i++) {
       await tdpos.mint(accounts[i], 1000, {from: accounts[0]});
     }
-    await tdpos.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
+    await tdpos.setProviderPoolMaxSize(PROVIDER_POOL_SIZE);
     await tdpos.setNumberOfActiveProviders(NUMBER_OF_ACTIVE_PROVIDERS);
   }
 

--- a/test/integration/DPOS.spec.js
+++ b/test/integration/DPOS.spec.js
@@ -5,6 +5,7 @@ contract('integration/TransmuteDPOS', (accounts) => {
   let tdpos;
   let contractAddress;
   const PROVIDER_POOL_SIZE = 4;
+  const NUMBER_OF_ACTIVE_PROVIDERS = 4;
 
   // Provider states
   const PROVIDER_UNREGISTERED = 0;
@@ -32,6 +33,7 @@ contract('integration/TransmuteDPOS', (accounts) => {
       await tdpos.mint(accounts[i], 1000, {from: accounts[0]});
     }
     await tdpos.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
+    await tdpos.setNumberOfActiveProviders(NUMBER_OF_ACTIVE_PROVIDERS);
   }
 
   describe('Registering as Providers', () => {

--- a/test/unit/ProviderPool.spec.js
+++ b/test/unit/ProviderPool.spec.js
@@ -138,12 +138,12 @@ contract('ProviderPool', (accounts) => {
 
     it('should update the new key', async () => {
       let provider = await pp.getProvider(accounts[0]);
-      let totalBondedAmount = provider[0];
-      assert.equal(1, totalBondedAmount);
+      let providerStake = provider[0];
+      assert.equal(1, providerStake);
       await pp.publicUpdateProvider(accounts[0], 9);
       provider = await pp.getProvider(accounts[0]);
-      totalBondedAmount = provider[0];
-      assert.equal(9, totalBondedAmount);
+      providerStake = provider[0];
+      assert.equal(9, providerStake);
     });
 
     it('should keep the value sorted', async () => {
@@ -159,7 +159,7 @@ contract('ProviderPool', (accounts) => {
       assert.equal(previousSize, providerPool[3]);
     });
 
-    it('should remove the provider if updated totalBondedAmount is zero', async () => {
+    it('should remove the provider if updated providerStake is zero', async () => {
       let providerPool = await pp.providerPool.call();
       const previousSize = providerPool[3].toNumber();
       assert.equal(true, await pp.containsProvider(accounts[2]));

--- a/test/unit/ProviderPool.spec.js
+++ b/test/unit/ProviderPool.spec.js
@@ -26,7 +26,7 @@ contract('ProviderPool', (accounts) => {
     }
   }
 
-  describe('setMaxNumberOfProviders', () => {
+  describe('setProviderPoolMaxSize', () => {
     before(async () => {
       pp = await ProviderPool.deployed();
     });
@@ -34,17 +34,17 @@ contract('ProviderPool', (accounts) => {
     it('should set the max number of providers allowed in the pool', async () => {
       let providerPool = await pp.providerPool.call();
       assert.equal(0, providerPool[2]); // max size
-      await pp.setMaxNumberOfProviders(7, {from: accounts[0]});
+      await pp.setProviderPoolMaxSize(7, {from: accounts[0]});
       providerPool = await pp.providerPool.call();
       assert.equal(7, providerPool[2]);
     });
 
     it('should fail if it is not called from the owner\'s address', async () => {
-      await assertFail( pp.setMaxNumberOfProviders(10, {from: accounts[1]}) );
+      await assertFail( pp.setProviderPoolMaxSize(10, {from: accounts[1]}) );
     });
 
     it('should fail if new size is less than current size', async () => {
-      await assertFail( pp.setMaxNumberOfProviders(6, {from: accounts[0]}) );
+      await assertFail( pp.setProviderPoolMaxSize(6, {from: accounts[0]}) );
     });
   });
 
@@ -89,7 +89,7 @@ contract('ProviderPool', (accounts) => {
   describe('containsProvider', () => {
     before(async () => {
       pp = await ProviderPool.new();
-      await pp.setMaxNumberOfProviders(10, {from: accounts[0]});
+      await pp.setProviderPoolMaxSize(10, {from: accounts[0]});
     });
 
     it('should return false if provider is not in the pool', async () => {
@@ -105,7 +105,7 @@ contract('ProviderPool', (accounts) => {
   describe('updateProvider', () => {
     before(async () => {
       pp = await ProviderPool.new();
-      await pp.setMaxNumberOfProviders(10, {from: accounts[0]});
+      await pp.setProviderPoolMaxSize(10, {from: accounts[0]});
       await pp.publicAddProvider(accounts[0], 1);
       await pp.publicAddProvider(accounts[1], 12);
       await pp.publicAddProvider(accounts[2], 3);

--- a/test/unit/ProviderPool.spec.js
+++ b/test/unit/ProviderPool.spec.js
@@ -48,6 +48,29 @@ contract('ProviderPool', (accounts) => {
     });
   });
 
+  describe('setNumberOfActiveProviders', () => {
+    it('should set the number of active providers', async () => {
+      let numberOfActiveProviders = await pp.numberOfActiveProviders.call();
+      assert.equal(0, numberOfActiveProviders); // max size
+      await pp.setNumberOfActiveProviders(5, {from: accounts[0]});
+      numberOfActiveProviders = await pp.numberOfActiveProviders.call();
+      assert.equal(5, numberOfActiveProviders);
+    });
+
+    it('should fail if it is not called from the owner\'s address', async () => {
+      await assertFail( pp.setNumberOfActiveProviders(7, {from: accounts[1]}) );
+    });
+
+    it('should fail if new value is more than pool maxSize', async () => {
+      await assertFail( pp.setNumberOfActiveProviders(8, {from: accounts[0]}) );
+    });
+
+    it('should work if new value is less or equal than pool maxSize', async () => {
+      await pp.setNumberOfActiveProviders(7, {from: accounts[0]});
+      await pp.setNumberOfActiveProviders(6, {from: accounts[0]});
+    });
+  });
+
   describe('addProvider', () => {
     it('should add a provider to the pool', async () => {
       let providerPool = await pp.providerPool.call();

--- a/test/unit/RoundManager.spec.js
+++ b/test/unit/RoundManager.spec.js
@@ -3,9 +3,12 @@ const {blockMiner, assertFail} = require('../utils.js');
 
 contract('RoundManager', (accounts) => {
   let rm;
+  // TODO: Caps
   const electionPeriodLength = 20;
   const rateLockDeadline = 5;
   const unbondingPeriod = 10;
+  const providerPoolMaxSize = 20;
+  const numberOfActiveProviders = 10;
 
   describe('initializeRound', () => {
     before(async () => {
@@ -13,9 +16,18 @@ contract('RoundManager', (accounts) => {
       await rm.setElectionPeriodLength(electionPeriodLength);
       await rm.setRateLockDeadline(rateLockDeadline);
       await rm.setUnbondingPeriod(unbondingPeriod);
+      // Set ProviderPool parameters
+      // TODO: Change name
+      await rm.setMaxNumberOfProviders(providerPoolMaxSize);
+    });
+
+    it('should fail if numberOfActiveProviders is not set', async () => {
+      await assertFail( rm.initializeRound() );
+      assert.equal(0, await rm.roundNumber.call());
     });
 
     it('should initialize the round', async () => {
+      await rm.setNumberOfActiveProviders(numberOfActiveProviders);
       await rm.initializeRound();
       assert.equal(1, await rm.roundNumber.call());
     });

--- a/test/unit/RoundManager.spec.js
+++ b/test/unit/RoundManager.spec.js
@@ -3,22 +3,21 @@ const {blockMiner, assertFail} = require('../utils.js');
 
 contract('RoundManager', (accounts) => {
   let rm;
-  // TODO: Caps
-  const electionPeriodLength = 20;
-  const rateLockDeadline = 5;
-  const unbondingPeriod = 10;
-  const providerPoolMaxSize = 20;
-  const numberOfActiveProviders = 10;
+  const ELECTION_PERIOD_LENGTH = 20;
+  const RATE_LOCK_DEADLINE = 5;
+  const UNBONDING_PERIOD = 10;
+  const PROVIDER_POOL_SIZE = 20;
+  const NUMBER_OF_ACTIVE_PROVIDERS = 10;
 
   describe('initializeRound', () => {
     before(async () => {
       rm = await RoundManager.deployed();
-      await rm.setElectionPeriodLength(electionPeriodLength);
-      await rm.setRateLockDeadline(rateLockDeadline);
-      await rm.setUnbondingPeriod(unbondingPeriod);
+      await rm.setElectionPeriodLength(ELECTION_PERIOD_LENGTH);
+      await rm.setRateLockDeadline(RATE_LOCK_DEADLINE);
+      await rm.setUnbondingPeriod(UNBONDING_PERIOD);
       // Set ProviderPool parameters
       // TODO: Change name
-      await rm.setMaxNumberOfProviders(providerPoolMaxSize);
+      await rm.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
     });
 
     it('should fail if numberOfActiveProviders is not set', async () => {
@@ -27,13 +26,13 @@ contract('RoundManager', (accounts) => {
     });
 
     it('should initialize the round', async () => {
-      await rm.setNumberOfActiveProviders(numberOfActiveProviders);
+      await rm.setNumberOfActiveProviders(NUMBER_OF_ACTIVE_PROVIDERS);
       await rm.initializeRound();
       assert.equal(1, await rm.roundNumber.call());
     });
 
     it('should initialize the next round electionPeriodLength blocks after initializing the last round', async () => {
-      await blockMiner.mine(electionPeriodLength - 1);
+      await blockMiner.mine(ELECTION_PERIOD_LENGTH - 1);
       await rm.initializeRound();
     });
 
@@ -42,7 +41,7 @@ contract('RoundManager', (accounts) => {
     });
 
     it('should fail to initialize a new round electionPeriodLength - 1 block after initializing the last round', async () => {
-      await blockMiner.mine(electionPeriodLength - 3);
+      await blockMiner.mine(ELECTION_PERIOD_LENGTH - 3);
       // Here the next initializeRound() call will happen on the (electionPeriodLength - 1)th block of the current round
       await assertFail(rm.initializeRound());
     });

--- a/test/unit/RoundManager.spec.js
+++ b/test/unit/RoundManager.spec.js
@@ -16,8 +16,7 @@ contract('RoundManager', (accounts) => {
       await rm.setRateLockDeadline(RATE_LOCK_DEADLINE);
       await rm.setUnbondingPeriod(UNBONDING_PERIOD);
       // Set ProviderPool parameters
-      // TODO: Change name
-      await rm.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
+      await rm.setProviderPoolMaxSize(PROVIDER_POOL_SIZE);
     });
 
     it('should fail if numberOfActiveProviders is not set', async () => {

--- a/test/unit/TransmuteDPOS.spec.js
+++ b/test/unit/TransmuteDPOS.spec.js
@@ -69,7 +69,6 @@ contract('TransmuteDPOS', (accounts) => {
       await assertFail( tdpos.provider(...STANDARD_PROVIDER_PARAMETERS, {from: accounts[0]}) );
     });
 
-    // TODO: search for totalBondedAmount
     it('should initially set providerStake to the amount the Provider bonded to himself', async () => {
       let providerStake = await tdpos.getProviderStake.call(accounts[0]);
       assert.equal(0, providerStake);

--- a/test/unit/TransmuteDPOS.spec.js
+++ b/test/unit/TransmuteDPOS.spec.js
@@ -157,24 +157,20 @@ contract('TransmuteDPOS', (accounts) => {
       // Check that provider isn't registered yet
       assert.equal(PROVIDER_UNREGISTERED, await tdpos.providerStatus.call(accounts[3]));
       // Check the size of the pool increases by 1
-      let providerPool = await tdpos.providerPool.call();
-      const previousSize = providerPool[3].toNumber();
+      const previousSize = await tdpos.getProviderPoolSize();
       await approveBondProvider(...STANDARD_PROVIDER_PARAMETERS, 1, accounts[3]);
-      providerPool = await tdpos.providerPool.call();
-      assert.equal(previousSize + 1, providerPool[3]);
+      assert.deepEqual(previousSize.add(1), await tdpos.getProviderPoolSize());
       // Check that the provider is registered in the pool now
       assert.equal(true, await tdpos.containsProvider(accounts[3]));
     });
 
     it('should fail if Provider is Unregistered and size == maxSize', async () => {
-      let providerPool = await tdpos.providerPool.call();
-      const maxSize = providerPool[2].toNumber();
-      let currentSize = providerPool[3];
+      const maxSize = await tdpos.getProviderPoolMaxSize();
+      let currentSize = await tdpos.getProviderPoolSize();
       assert.isAbove(maxSize, currentSize.toNumber());
       await approveBondProvider(...STANDARD_PROVIDER_PARAMETERS, 1, accounts[4]);
-      providerPool = await tdpos.providerPool.call();
-      currentSize = providerPool[3];
-      assert.equal(maxSize, currentSize);
+      currentSize = await tdpos.getProviderPoolSize();
+      assert.deepEqual(maxSize, currentSize);
       await assertFail( approveBondProvider(...STANDARD_PROVIDER_PARAMETERS, 1, accounts[5]) );
     });
 
@@ -182,7 +178,6 @@ contract('TransmuteDPOS', (accounts) => {
       let provider = await tdpos.providers.call(accounts[4]);
       pricePerStorageMineral = provider[0];
       assert.equal(PRICE_PER_STORAGE_MINERAL, pricePerStorageMineral);
-       [];
       const UPDATED_PRICE_PER_STORAGE_MINERAL = 21;
       await tdpos.provider(UPDATED_PRICE_PER_STORAGE_MINERAL, PRICE_PER_COMPUTE_MINERAL, BLOCK_REWARD_CUT, FEE_SHARE, {from: accounts[4]});
       provider = await tdpos.providers.call(accounts[4]);

--- a/test/unit/TransmuteDPOS.spec.js
+++ b/test/unit/TransmuteDPOS.spec.js
@@ -41,7 +41,7 @@ contract('TransmuteDPOS', (accounts) => {
     for (let i = 0; i < 10; i++) {
       await tdpos.mint(accounts[i], 1000, {from: accounts[0]});
     }
-    await tdpos.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
+    await tdpos.setProviderPoolMaxSize(PROVIDER_POOL_SIZE);
     await tdpos.setNumberOfActiveProviders(NUMBER_OF_ACTIVE_PROVIDERS);
     const electionPeriodEndBlock = await roundManagerHelper.getElectionPeriodEndBlock(tdpos);
     await blockMiner.mineUntilBlock(electionPeriodEndBlock);
@@ -55,7 +55,7 @@ contract('TransmuteDPOS', (accounts) => {
       for (let i = 0; i < 5; i++) {
         await tdpos.mint(accounts[i], 1000, {from: accounts[0]});
       }
-      await tdpos.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
+      await tdpos.setProviderPoolMaxSize(PROVIDER_POOL_SIZE);
       await tdpos.setNumberOfActiveProviders(NUMBER_OF_ACTIVE_PROVIDERS);
     });
 

--- a/test/unit/TransmuteDPOS.spec.js
+++ b/test/unit/TransmuteDPOS.spec.js
@@ -6,6 +6,8 @@ contract('TransmuteDPOS', (accounts) => {
   let tdpos;
   let contractAddress;
   const PROVIDER_POOL_SIZE = 5;
+  const NUMBER_OF_ACTIVE_PROVIDERS = 4;
+
   // Provider states
   const PROVIDER_UNREGISTERED = 0;
   const PROVIDER_REGISTERED = 1;
@@ -40,6 +42,7 @@ contract('TransmuteDPOS', (accounts) => {
       await tdpos.mint(accounts[i], 1000, {from: accounts[0]});
     }
     await tdpos.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
+    await tdpos.setNumberOfActiveProviders(NUMBER_OF_ACTIVE_PROVIDERS);
     const electionPeriodEndBlock = await roundManagerHelper.getElectionPeriodEndBlock(tdpos);
     await blockMiner.mineUntilBlock(electionPeriodEndBlock);
     await tdpos.initializeRound();
@@ -53,6 +56,7 @@ contract('TransmuteDPOS', (accounts) => {
         await tdpos.mint(accounts[i], 1000, {from: accounts[0]});
       }
       await tdpos.setMaxNumberOfProviders(PROVIDER_POOL_SIZE);
+      await tdpos.setNumberOfActiveProviders(NUMBER_OF_ACTIVE_PROVIDERS);
     });
 
     beforeEach(async () => {

--- a/test/unit/TransmuteDPOS.spec.js
+++ b/test/unit/TransmuteDPOS.spec.js
@@ -127,11 +127,11 @@ contract('TransmuteDPOS', (accounts) => {
       assert.web3Event(result, {
         event: 'ProviderAdded',
         args: {
-          _provider: accounts[2],
-          _pricePerStorageMineral: PRICE_PER_STORAGE_MINERAL,
-          _pricePerComputeMineral: PRICE_PER_COMPUTE_MINERAL,
-          _blockRewardCut: BLOCK_REWARD_CUT,
-          _feeShare: FEE_SHARE,
+          provider: accounts[2],
+          pricePerStorageMineral: PRICE_PER_STORAGE_MINERAL,
+          pricePerComputeMineral: PRICE_PER_COMPUTE_MINERAL,
+          blockRewardCut: BLOCK_REWARD_CUT,
+          feeShare: FEE_SHARE,
         },
       });
     });
@@ -145,11 +145,11 @@ contract('TransmuteDPOS', (accounts) => {
       assert.web3Event(result, {
         event: 'ProviderUpdated',
         args: {
-          _provider: accounts[2],
-          _pricePerStorageMineral: UPDATED_PRICE_PER_STORAGE_MINERAL,
-          _pricePerComputeMineral: UPDATED_PRICE_PER_COMPUTE_MINERAL,
-          _blockRewardCut: UPDATED_BLOCK_REWARD_CUT,
-          _feeShare: UPDATED_FEE_SHARE,
+          provider: accounts[2],
+          pricePerStorageMineral: UPDATED_PRICE_PER_STORAGE_MINERAL,
+          pricePerComputeMineral: UPDATED_PRICE_PER_COMPUTE_MINERAL,
+          blockRewardCut: UPDATED_BLOCK_REWARD_CUT,
+          feeShare: UPDATED_FEE_SHARE,
         },
       });
     });
@@ -226,7 +226,7 @@ contract('TransmuteDPOS', (accounts) => {
       assert.web3Event(result, {
         event: 'ProviderResigned',
         args: {
-          _provider: accounts[2],
+          provider: accounts[2],
         },
       });
     });
@@ -323,9 +323,9 @@ contract('TransmuteDPOS', (accounts) => {
       assert.web3Event(result, {
         event: 'DelegatorBonded',
         args: {
-          _delegator: accounts[4],
-          _provider: accounts[0],
-          _amount: bondedAmount,
+          delegator: accounts[4],
+          provider: accounts[0],
+          amount: bondedAmount,
         },
       });
     });
@@ -398,9 +398,9 @@ contract('TransmuteDPOS', (accounts) => {
       assert.web3Event(result, {
         event: 'DelegatorUnbonded',
         args: {
-          _delegator: accounts[5],
-          _provider: accounts[0],
-          _amount: 300,
+          delegator: accounts[5],
+          provider: accounts[0],
+          amount: 300,
         },
       });
     });

--- a/test/unit/TransmuteDPOS.spec.js
+++ b/test/unit/TransmuteDPOS.spec.js
@@ -167,7 +167,7 @@ contract('TransmuteDPOS', (accounts) => {
     it('should fail if Provider is Unregistered and size == maxSize', async () => {
       const maxSize = await tdpos.getProviderPoolMaxSize();
       let currentSize = await tdpos.getProviderPoolSize();
-      assert.isAbove(maxSize, currentSize.toNumber());
+      assert.isAbove(maxSize.toNumber(), currentSize.toNumber());
       await approveBondProvider(...STANDARD_PROVIDER_PARAMETERS, 1, accounts[4]);
       currentSize = await tdpos.getProviderPoolSize();
       assert.deepEqual(maxSize, currentSize);


### PR DESCRIPTION
https://transmute.atlassian.net/browse/ENG-486

- added the concept of active providers: They are the top `numberOfActiveProviders` (ranked by stake) of all Providers registered in the providerPool.
- `initializeRound()` now calls `setActiveProviders` which creates a list of active provider addresses, sums up their total stake (to be used later for electing the active provider that will perform a job)
- `setActiveProviders()` also freezes providersParameters: when the function is called, all the parameters (stored in `providers` mapping) of active providers are stored in the `activeProviders` mapping. That way, if an active provider changes his parameters, they will take effect only at the beginning of next round (next time `setActiveProviders()` is called) 
- Refactor a bunch of stuff